### PR TITLE
Fix statistics tab data handling

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -523,9 +523,11 @@ class PekkasPokalApp {
         this.state.competitionData,
         this.state.filters
       );
-      
-      this.modules.uiComponents.updateStatisticsView(filteredData);
-      this.modules.chartManager.updateStatisticsCharts(filteredData);
+      // FilterManager returns an object containing competitions, participants and the
+      // original data. The statistics components only need the competitions array,
+      // so pass that to avoid runtime errors when iterating over the result.
+      this.modules.uiComponents.updateStatisticsView(filteredData.competitions);
+      this.modules.chartManager.updateStatisticsCharts(filteredData.competitions);
     }
   }
 


### PR DESCRIPTION
## Summary
- Pass only the competitions array to statistics view and charts
- Add clarifying comments to avoid runtime errors when iterating filtered data

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a76ce921c88329a4bbd7563445edcc