### PR TITLE
Replace performance trend chart with wins chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,9 +185,9 @@
       <!-- Charts -->
       <div class="chart-container">
         <div class="chart-header">
-          <div class="chart-title">📊 Prestationsutveckling över Tid</div>
+          <div class="chart-title">🏆 Vinster per Deltagare</div>
         </div>
-        <canvas id="performance-trend-chart"></canvas>
+        <canvas id="wins-chart"></canvas>
       </div>
     </div>
 

--- a/src/scripts/chart-manager.js
+++ b/src/scripts/chart-manager.js
@@ -201,6 +201,69 @@ class ChartManager {
   }
 
   /**
+   * Create wins distribution chart
+   */
+  createWinsChart(data) {
+    const ctx = document.getElementById('wins-chart');
+    if (!ctx) {
+      console.warn('Wins chart canvas not found');
+      return;
+    }
+
+    this.destroyChart('wins-chart');
+
+    const winCounts = {};
+    data.competitions.forEach(comp => {
+      if (comp.winner) {
+        winCounts[comp.winner] = (winCounts[comp.winner] || 0) + 1;
+      }
+    });
+
+    const topWinners = Object.entries(winCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 8);
+
+    const options = {
+      ...this.defaultOptions,
+      plugins: {
+        ...this.defaultOptions.plugins,
+        legend: { display: false }
+      },
+      scales: {
+        ...this.defaultOptions.scales,
+        y: {
+          ...this.defaultOptions.scales.y,
+          beginAtZero: true,
+          title: { display: true, text: 'Antal Vinster', color: '#a8b2d1' }
+        },
+        x: {
+          ...this.defaultOptions.scales.x,
+          title: { display: true, text: 'Deltagare', color: '#a8b2d1' }
+        }
+      }
+    };
+
+    const chart = new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: topWinners.map(([name]) => name),
+        datasets: [
+          {
+            label: 'Vinster',
+            data: topWinners.map(([, wins]) => wins),
+            backgroundColor: this.colorPalette.primary,
+            borderColor: this.colorPalette.primary,
+            borderWidth: 1
+          }
+        ]
+      },
+      options: options
+    });
+
+    this.charts.set('wins-chart', chart);
+  }
+
+  /**
    * Create medal distribution chart
    */
   createMedalChart(medalCounts) {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -442,9 +442,9 @@ class PekkasPokalApp {
       this.modules.uiComponents.renderFunStats(funStats);
     }
     
-    // Create performance chart
+    // Create wins chart
     if (this.modules.chartManager) {
-      this.modules.chartManager.createPerformanceTrendChart(data);
+      this.modules.chartManager.createWinsChart(data);
     }
   }
 


### PR DESCRIPTION
## Summary
- swap confusing performance trend graph for a clearer wins-per-participant bar chart
- add chart manager support for rendering the wins distribution
- hook dashboard to render the new wins chart

## Testing
- `npm run lint` *(fails: ReferenceError: Cannot read config file: /workspace/pekkas-pokal/.eslintrc.js)*
- `npm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a770b7b78483299d665604b324ec37