### PR TITLE
Sort average position chart years chronologically

### DIFF
--- a/src/scripts/chart-manager.js
+++ b/src/scripts/chart-manager.js
@@ -394,15 +394,19 @@ class ChartManager {
     const competitor = window.PekkasPokalApp?.getState()?.competitionData?.participants?.find(p => p.id === competitorId);
     const competitorName = competitor ? competitor.name : 'Okänd';
     
-    const years = [];
-    const positions = [];
-    
+    const data = [];
+
     filteredData.forEach(comp => {
       if (comp.scores[competitorId]) {
-        years.push(comp.year);
-        positions.push(comp.scores[competitorId]);
+        data.push({ year: comp.year, position: comp.scores[competitorId] });
       }
     });
+
+    // Sort chronologically so earliest year appears first on x-axis
+    data.sort((a, b) => a.year - b.year);
+
+    const years = data.map(d => d.year);
+    const positions = data.map(d => d.position);
 
     const options = {
       ...this.defaultOptions,


### PR DESCRIPTION
## Summary
- Ensure individual average position chart sorts years chronologically so x-axis runs from earliest to latest.

## Testing
- `npm test` *(fails: No test files found, exiting with code 1)*
- `npm run lint` *(fails: ESLint config treated as ES module)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a771426e40832991037449a231755a