### PR TITLE
feat: expand dashboard insights

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,42 @@
         </div>
         <canvas id="wins-chart"></canvas>
       </div>
+
+      <div class="dashboard-extras">
+        <div class="extra-card" id="upcoming-event">
+          <h3>⏳ Nästa Tävling</h3>
+          <div id="next-event-name">—</div>
+          <div id="next-event-countdown"></div>
+        </div>
+
+        <div class="extra-card" id="leaderboard-snapshot">
+          <h3>🏅 Topplista</h3>
+          <input id="leaderboard-search" class="filter-input" type="text" placeholder="Sök deltagare..." />
+          <ul id="leaderboard-list"></ul>
+        </div>
+
+        <div class="extra-card" id="recent-achievements">
+          <h3>🎖️ Nya Achievements</h3>
+          <ul id="recent-achievements-list"></ul>
+        </div>
+
+        <div class="extra-card" id="rivalry-section">
+          <h3>⚔️ Rivalitet</h3>
+          <div id="rivalry-info">—</div>
+        </div>
+
+        <div class="extra-card" id="records-section">
+          <h3>📚 Rekordbok</h3>
+          <ul id="record-list"></ul>
+        </div>
+
+        <div class="chart-container">
+          <div class="chart-header">
+            <div class="chart-title">👥 Deltagande per År</div>
+          </div>
+          <canvas id="dashboard-participation-chart"></canvas>
+        </div>
+      </div>
     </div>
 
     <!-- Medal Tally Tab -->

--- a/src/scripts/chart-manager.js
+++ b/src/scripts/chart-manager.js
@@ -696,6 +696,69 @@ class ChartManager {
   }
 
   /**
+   * Create dashboard participation overview chart
+   */
+  createDashboardParticipationChart(data) {
+    const ctx = document.getElementById('dashboard-participation-chart');
+    if (!ctx) {
+      console.warn('Dashboard participation chart canvas not found');
+      return;
+    }
+
+    this.destroyChart('dashboard-participation-chart');
+
+    const yearParticipation = {};
+    data.competitions.forEach(comp => {
+      yearParticipation[comp.year] = comp.participantCount;
+    });
+
+    const years = Object.keys(yearParticipation).sort();
+    const participation = years.map(year => yearParticipation[year]);
+
+    const options = {
+      ...this.defaultOptions,
+      scales: {
+        ...this.defaultOptions.scales,
+        y: {
+          ...this.defaultOptions.scales.y,
+          beginAtZero: true,
+          title: {
+            display: true,
+            text: 'Antal deltagare',
+            color: '#a8b2d1'
+          }
+        },
+        x: {
+          ...this.defaultOptions.scales.x,
+          title: {
+            display: true,
+            text: 'År',
+            color: '#a8b2d1'
+          }
+        }
+      }
+    };
+
+    const chart = new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: years,
+        datasets: [{
+          label: 'Antal Deltagare',
+          data: participation,
+          backgroundColor: this.colorPalette.primary + '80',
+          borderColor: this.colorPalette.primary,
+          borderWidth: 2,
+          borderRadius: 4
+        }]
+      },
+      options: options
+    });
+
+    this.charts.set('dashboard-participation-chart', chart);
+  }
+
+  /**
    * Update statistics charts
    */
   updateStatisticsCharts(filteredData) {

--- a/src/scripts/data-manager.js
+++ b/src/scripts/data-manager.js
@@ -198,7 +198,9 @@ class DataManager {
     
     rows.forEach((row, index) => {
       try {
-        const year = this.parseYear(row['År']);
+        const rawDate = row['År'];
+        const year = this.parseYear(rawDate);
+        const date = this.parseDate(rawDate);
         const name = row['Tävling']?.trim();
         const location = row['Plats']?.trim() || '';
         const arranger3rd = row['Arrangör 3:a']?.trim() || '';
@@ -213,6 +215,7 @@ class DataManager {
           competitions.push({
             id: `c${competitions.length + 1}`,
             year: year,
+            date: date,
             name: 'Covid',
             location: '',
             winner: null,
@@ -248,6 +251,7 @@ class DataManager {
         competitions.push({
           id: `c${competitions.length + 1}`,
           year: year,
+          date: date,
           name: name,
           location: location,
           winner: winner,
@@ -294,6 +298,22 @@ class DataManager {
     // Handle simple year
     const year = parseInt(str);
     return isNaN(year) ? null : year;
+  }
+
+  /**
+   * Parse full date from string if available
+   */
+  parseDate(dateString) {
+    if (!dateString) return null;
+
+    const str = dateString.toString().trim();
+    if (str.includes('-')) {
+      const d = new Date(str);
+      return isNaN(d.getTime()) ? null : d;
+    }
+
+    const year = parseInt(str);
+    return isNaN(year) ? null : new Date(year, 0, 1);
   }
 
   /**

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -442,10 +442,18 @@ class PekkasPokalApp {
       this.modules.uiComponents.renderFunStats(funStats);
     }
     
-    // Create wins chart
+    // Create charts
     if (this.modules.chartManager) {
       this.modules.chartManager.createWinsChart(data);
+      this.modules.chartManager.createDashboardParticipationChart(data);
     }
+
+    // Render additional dashboard sections
+    this.renderUpcomingEvent(data);
+    this.renderLeaderboard(data);
+    this.renderAchievementsHighlight(data);
+    this.renderRivalry(data);
+    this.renderRecords(data);
   }
 
   /**
@@ -477,6 +485,178 @@ class PekkasPokalApp {
     if (latestComp && latestComp.winner) {
       this.updateElement('current-champion', latestComp.winner);
       this.updateElement('champ-comp', `${latestComp.year} ${latestComp.name}`);
+    }
+  }
+
+  /**
+   * Render upcoming event and countdown
+   */
+  renderUpcomingEvent(data) {
+    const nameEl = document.getElementById('next-event-name');
+    const countdownEl = document.getElementById('next-event-countdown');
+    if (!nameEl || !countdownEl) return;
+
+    const now = new Date();
+    const upcoming = data.competitions
+      .filter(c => c.date && c.date > now)
+      .sort((a, b) => a.date - b.date)[0];
+
+    if (!upcoming) {
+      nameEl.textContent = 'Ingen planerad';
+      countdownEl.textContent = '';
+      return;
+    }
+
+    nameEl.textContent = `${upcoming.year} ${upcoming.name}`;
+
+    const updateCountdown = () => {
+      const diff = upcoming.date - new Date();
+      if (diff <= 0) {
+        countdownEl.textContent = 'Pågår!';
+        return;
+      }
+      const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+      const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+      countdownEl.textContent = `${days}d ${hours}h`;
+    };
+
+    updateCountdown();
+    setInterval(updateCountdown, 60 * 60 * 1000);
+  }
+
+  /**
+   * Render leaderboard snapshot with search
+   */
+  renderLeaderboard(data) {
+    const list = document.getElementById('leaderboard-list');
+    const search = document.getElementById('leaderboard-search');
+    if (!list || !search || !this.modules.statistics) return;
+
+    const winCounts = this.modules.statistics.calculateWinCounts(data.competitions);
+    const sorted = Object.entries(winCounts).sort((a, b) => b[1] - a[1]);
+
+    const render = () => {
+      const term = search.value.toLowerCase();
+      list.innerHTML = '';
+      sorted
+        .filter(([name]) => name.toLowerCase().includes(term))
+        .slice(0, 5)
+        .forEach(([name, count], index) => {
+          const li = document.createElement('li');
+          li.textContent = `${index + 1}. ${name} (${count})`;
+          list.appendChild(li);
+        });
+    };
+
+    search.addEventListener('input', render);
+    render();
+  }
+
+  /**
+   * Highlight recent achievements
+   */
+  renderAchievementsHighlight(data) {
+    const list = document.getElementById('recent-achievements-list');
+    if (!list) return;
+
+    const latestComp = data.competitions[0];
+    const achievementsData = data.participantAchievements || {};
+    let achievements = [];
+
+    if (latestComp && latestComp.winner) {
+      achievements = achievementsData[latestComp.winner] || [];
+    }
+
+    list.innerHTML = '';
+    achievements.slice(0, 3).forEach(achId => {
+      const def = window.ACHIEVEMENT_DEFINITIONS?.find(a => a.id === achId);
+      if (def) {
+        const li = document.createElement('li');
+        li.textContent = `${def.icon} ${def.name}`;
+        list.appendChild(li);
+      }
+    });
+
+    if (list.childElementCount === 0) {
+      const li = document.createElement('li');
+      li.textContent = 'Inga nya achievements';
+      list.appendChild(li);
+    }
+  }
+
+  /**
+   * Render rivalry summary
+   */
+  renderRivalry(data) {
+    const el = document.getElementById('rivalry-info');
+    if (!el || !this.modules.statistics) return;
+    const rivalry = this.modules.statistics.findBiggestRivalry(data);
+    el.textContent = rivalry || 'Ingen tydlig rivalitet';
+  }
+
+  /**
+   * Render record book section
+   */
+  renderRecords(data) {
+    const list = document.getElementById('record-list');
+    if (!list || !this.modules.statistics) return;
+
+    list.innerHTML = '';
+
+    // Longest winning streak
+    const comps = [...data.competitions].sort((a, b) => a.year - b.year);
+    let bestStreak = 0;
+    let streakHolder = null;
+    let currentWinner = null;
+    let currentStreak = 0;
+
+    comps.forEach(comp => {
+      if (comp.winner) {
+        if (comp.winner === currentWinner) {
+          currentStreak++;
+        } else {
+          currentWinner = comp.winner;
+          currentStreak = 1;
+        }
+        if (currentStreak > bestStreak) {
+          bestStreak = currentStreak;
+          streakHolder = currentWinner;
+        }
+      } else {
+        currentWinner = null;
+        currentStreak = 0;
+      }
+    });
+
+    if (streakHolder) {
+      const li = document.createElement('li');
+      li.textContent = `Längsta segersvit: ${streakHolder} (${bestStreak})`;
+      list.appendChild(li);
+    }
+
+    // Most participants in a year
+    const mostPart = comps.reduce((max, comp) =>
+      comp.participantCount > (max?.participantCount || 0) ? comp : max,
+    null);
+    if (mostPart) {
+      const li = document.createElement('li');
+      li.textContent = `Flest deltagare: ${mostPart.year} (${mostPart.participantCount})`;
+      list.appendChild(li);
+    }
+
+    // Most wins overall
+    const winCounts = this.modules.statistics.calculateWinCounts(data.competitions);
+    const topWinner = Object.entries(winCounts).sort((a, b) => b[1] - a[1])[0];
+    if (topWinner) {
+      const li = document.createElement('li');
+      li.textContent = `Flest vinster: ${topWinner[0]} (${topWinner[1]})`;
+      list.appendChild(li);
+    }
+
+    if (list.childElementCount === 0) {
+      const li = document.createElement('li');
+      li.textContent = 'Inga rekord';
+      list.appendChild(li);
     }
   }
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -131,6 +131,18 @@
   border-color: var(--accent);
 }
 
+.extra-card {
+  background: var(--bg-card);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-lg);
+  border: 1px solid rgba(102, 126, 234, 0.2);
+  margin-top: var(--spacing-lg);
+}
+
+.extra-card h3 {
+  margin-top: 0;
+}
+
 .stat-icon {
   font-size: var(--text-4xl);
   margin-bottom: var(--spacing-sm);
@@ -781,6 +793,22 @@
 
 .filter-select:hover,
 .filter-select:focus {
+  border-color: var(--accent);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+.filter-input {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(102, 126, 234, 0.3);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  min-width: 150px;
+}
+
+.filter-input:focus {
   border-color: var(--accent);
   outline: none;
   box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -28,6 +28,17 @@
   margin-bottom: var(--spacing-xl);
 }
 
+.dashboard-extras {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--spacing-lg);
+  margin-top: var(--spacing-xl);
+}
+
+.dashboard-extras .chart-container {
+  grid-column: 1 / -1;
+}
+
 /* Participant Cards Grid */
 .participant-cards {
   display: grid;


### PR DESCRIPTION
## Summary
- add upcoming event countdown, leaderboard snapshot, and achievement highlights to dashboard
- compute rivalry and records and show participation chart overview
- parse and store competition dates for scheduling features

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: module is not defined in ES module scope)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7741fe7408329a02317cb34f2f539