### PR TITLE
Add contestant filter to achievements page

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,6 +274,11 @@
           <span>👥</span>
           <span>Deltagare & Deras Achievements</span>
         </h2>
+        <div class="achievements-controls">
+          <select id="achievement-competitor-filter" class="filter-select">
+            <option value="all">Alla Deltagare</option>
+          </select>
+        </div>
         <div class="participant-cards" id="participant-cards"></div>
       </section>
 

--- a/src/scripts/ui-components.js
+++ b/src/scripts/ui-components.js
@@ -198,7 +198,7 @@ class UIComponents {
       : window.ACHIEVEMENT_DEFINITIONS.filter(a => a.category === category);
 
     // Get current achievement data
-    const participantAchievements = window.PekkasPokalApp?.getState()?.competitionData?.participantAchievements || {};
+    const participantAchievements = window.PekkasPokalApp?.getFilteredParticipantAchievements?.() || {};
 
     filteredAchievements.forEach((ach, index) => {
       // Find holders of this achievement


### PR DESCRIPTION
## Summary
- allow filtering achievements by contestant with new dropdown
- sync competitor filters across statistics and achievements
- render achievements grid using filtered participant data

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a778ab9c8c8329b6f0189e889e3335