### PR TITLE
Remove dashboard leaderboard and rivalry sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,20 +197,9 @@
           <div id="next-event-countdown"></div>
         </div>
 
-        <div class="extra-card" id="leaderboard-snapshot">
-          <h3>🏅 Topplista</h3>
-          <input id="leaderboard-search" class="filter-input" type="text" placeholder="Sök deltagare..." />
-          <ul id="leaderboard-list"></ul>
-        </div>
-
         <div class="extra-card" id="recent-achievements">
           <h3>🎖️ Nya Achievements</h3>
           <ul id="recent-achievements-list"></ul>
-        </div>
-
-        <div class="extra-card" id="rivalry-section">
-          <h3>⚔️ Rivalitet</h3>
-          <div id="rivalry-info">—</div>
         </div>
 
         <div class="extra-card" id="records-section">

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -464,9 +464,7 @@ class PekkasPokalApp {
 
     // Render additional dashboard sections
     this.renderUpcomingEvent(data);
-    this.renderLeaderboard(data);
     this.renderAchievementsHighlight(data);
-    this.renderRivalry(data);
     this.renderRecords(data);
   }
 
@@ -539,34 +537,6 @@ class PekkasPokalApp {
   }
 
   /**
-   * Render leaderboard snapshot with search
-   */
-  renderLeaderboard(data) {
-    const list = document.getElementById('leaderboard-list');
-    const search = document.getElementById('leaderboard-search');
-    if (!list || !search || !this.modules.statistics) return;
-
-    const winCounts = this.modules.statistics.calculateWinCounts(data.competitions);
-    const sorted = Object.entries(winCounts).sort((a, b) => b[1] - a[1]);
-
-    const render = () => {
-      const term = search.value.toLowerCase();
-      list.innerHTML = '';
-      sorted
-        .filter(([name]) => name.toLowerCase().includes(term))
-        .slice(0, 5)
-        .forEach(([name, count], index) => {
-          const li = document.createElement('li');
-          li.textContent = `${index + 1}. ${name} (${count})`;
-          list.appendChild(li);
-        });
-    };
-
-    search.addEventListener('input', render);
-    render();
-  }
-
-  /**
    * Highlight recent achievements
    */
   renderAchievementsHighlight(data) {
@@ -596,16 +566,6 @@ class PekkasPokalApp {
       li.textContent = 'Inga nya achievements';
       list.appendChild(li);
     }
-  }
-
-  /**
-   * Render rivalry summary
-   */
-  renderRivalry(data) {
-    const el = document.getElementById('rivalry-info');
-    if (!el || !this.modules.statistics) return;
-    const rivalry = this.modules.statistics.findBiggestRivalry(data);
-    el.textContent = rivalry || 'Ingen tydlig rivalitet';
   }
 
   /**


### PR DESCRIPTION
## Summary
- remove Topplista and Rivalitet extra cards from the dashboard
- drop related render functions and calls in main controller

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: Cannot read config file: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a77c2a3b8c832990b0cf551f45af2e