### PR TITLE
Fix competition type filter in statistics tab

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -187,7 +187,9 @@ class PekkasPokalApp {
             this.updateElement('competitor-filter', e.target.value, 'value');
             this.updateElement('achievement-competitor-filter', e.target.value, 'value');
           } else {
-            filterType = e.target.id.replace('-filter', '').replace('-', '');
+            filterType = e.target.id
+              .replace('-filter', '')
+              .replace(/-([a-z])/g, (_, c) => c.toUpperCase());
           }
 
           this.state.filters[filterType] = e.target.value;


### PR DESCRIPTION
## Summary
- correct competition type filter mapping so statistics tab filters by competition properly

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a77de61a648329b5fbacc087918d8d