### PR TITLE
Add placement trend chart and multi-select competitor filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
           <span>Deltagare & Deras Achievements</span>
         </h2>
         <div class="achievements-controls">
-          <select id="achievement-competitor-filter" class="filter-select">
+          <select id="achievement-competitor-filter" class="filter-select" multiple size="1">
             <option value="all">Alla Deltagare</option>
           </select>
         </div>
@@ -296,7 +296,7 @@
     <div id="statistics" class="tab-content">
       <!-- Enhanced Filters -->
       <div class="stats-controls">
-        <select id="competitor-filter" class="filter-select">
+        <select id="competitor-filter" class="filter-select" multiple size="1">
           <option value="all">Alla Deltagare</option>
         </select>
         <select id="timeframe-filter" class="filter-select">
@@ -335,6 +335,13 @@
           </div>
           <canvas id="participation-chart"></canvas>
         </div>
+      </div>
+
+      <div class="chart-container">
+        <div class="chart-header">
+          <div class="chart-title">📉 Placering per År</div>
+        </div>
+        <canvas id="placement-trend-chart"></canvas>
       </div>
     </div>
   </div>

--- a/src/scripts/filters.js
+++ b/src/scripts/filters.js
@@ -34,8 +34,11 @@ class FilterManager {
     
     // Apply competitor filter (affects both competitions and participants)
     if (filters.competitor !== 'all') {
-      filteredParticipants = filteredParticipants.filter(p => p.id === filters.competitor);
-      filteredCompetitions = this.applyCompetitorFilter(filteredCompetitions, filters.competitor);
+      const ids = Array.isArray(filters.competitor)
+        ? filters.competitor
+        : [filters.competitor];
+      filteredParticipants = filteredParticipants.filter(p => ids.includes(p.id));
+      filteredCompetitions = this.applyCompetitorFilter(filteredCompetitions, ids);
     }
     
     const endTime = performance.now();
@@ -91,15 +94,19 @@ class FilterManager {
   /**
    * Apply competitor filter
    */
-  applyCompetitorFilter(competitions, competitorId) {
-    if (competitorId === 'all') return competitions;
-    
-    return competitions.map(comp => ({
-      ...comp,
-      scores: Object.fromEntries(
-        Object.entries(comp.scores).filter(([pId]) => pId === competitorId)
-      )
-    })).filter(comp => Object.keys(comp.scores).length > 0);
+  applyCompetitorFilter(competitions, competitorIds) {
+    if (competitorIds === 'all') return competitions;
+
+    const ids = Array.isArray(competitorIds) ? competitorIds : [competitorIds];
+
+    return competitions
+      .map(comp => ({
+        ...comp,
+        scores: Object.fromEntries(
+          Object.entries(comp.scores).filter(([pId]) => ids.includes(pId))
+        )
+      }))
+      .filter(comp => Object.keys(comp.scores).length > 0);
   }
 
   /**

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -781,7 +781,7 @@
 
 .filter-select {
   padding: var(--spacing-sm) var(--spacing-md);
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--bg-card);
   border: 1px solid rgba(102, 126, 234, 0.3);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
@@ -789,6 +789,11 @@
   cursor: pointer;
   transition: all var(--transition-normal);
   min-width: 150px;
+}
+
+.filter-select option {
+  background: var(--bg-card);
+  color: var(--text-primary);
 }
 
 .filter-select:hover,


### PR DESCRIPTION
## Summary
- Allow selecting multiple competitors in statistics filters and sync across views
- Add placement trend chart showing yearly positions per competitor
- Style filter dropdowns for better desktop visibility

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a781f6defc8329830f52432db10c01