### PR TITLE
Improve desktop competitor filter usability

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -8,17 +8,17 @@ class PekkasPokalApp {
     this.modules = {};
     this.state = {
       initialized: false,
-      currentTab: 'dashboard',
+      currentTab: "dashboard",
       competitionData: null,
       filters: {
-        competitor: 'all',
-        timeframe: 'all',
-        competitionType: 'all'
-      }
+        competitor: "all",
+        timeframe: "all",
+        competitionType: "all",
+      },
     };
-    
-    console.log('🏆 PekkasPokalApp starting...');
-    
+
+    console.log("🏆 PekkasPokalApp starting...");
+
     // Initialize immediately
     this.initialize();
   }
@@ -28,35 +28,34 @@ class PekkasPokalApp {
    */
   async initialize() {
     try {
-      console.log('🏆 Initializing Pekkas Pokal...');
-      
+      console.log("🏆 Initializing Pekkas Pokal...");
+
       // Initialize modules
       await this.initializeModules();
-      console.log('✅ Modules initialized');
-      
+      console.log("✅ Modules initialized");
+
       // Setup event listeners
       this.setupEventListeners();
-      console.log('✅ Event listeners setup');
-      
+      console.log("✅ Event listeners setup");
+
       // Load data
       await this.loadData();
-      console.log('✅ Data loaded');
-      
+      console.log("✅ Data loaded");
+
       // Initial render
       this.render();
-      console.log('✅ Initial render complete');
-      
+      console.log("✅ Initial render complete");
+
       // Hide loading screen
-      const loadingScreen = document.getElementById('loading-screen');
+      const loadingScreen = document.getElementById("loading-screen");
       if (loadingScreen) {
-        loadingScreen.style.display = 'none';
+        loadingScreen.style.display = "none";
       }
-      
+
       this.state.initialized = true;
-      console.log('🎉 Pekkas Pokal initialized successfully!');
-      
+      console.log("🎉 Pekkas Pokal initialized successfully!");
     } catch (error) {
-      console.error('❌ Failed to initialize:', error);
+      console.error("❌ Failed to initialize:", error);
       this.showError(`Fel vid initialisering: ${error.message}`);
     }
   }
@@ -65,52 +64,52 @@ class PekkasPokalApp {
    * Initialize all modules
    */
   async initializeModules() {
-    console.log('📦 Initializing modules...');
-    
+    console.log("📦 Initializing modules...");
+
     // Initialize modules with safe fallbacks
     try {
       // Critical module - DataManager
-      if (typeof DataManager !== 'undefined') {
+      if (typeof DataManager !== "undefined") {
         this.modules.dataManager = new DataManager();
-        console.log('✅ DataManager initialized');
+        console.log("✅ DataManager initialized");
       } else {
         // Create a minimal DataManager if missing
-        console.warn('DataManager missing, creating minimal version');
+        console.warn("DataManager missing, creating minimal version");
         this.modules.dataManager = {
           loadCSVData: () => this.getEmbeddedData(),
-          processData: (data, headers) => this.getEmbeddedData()
+          processData: (data, headers) => this.getEmbeddedData(),
         };
       }
-      
+
       // Optional modules - create safely
-      if (typeof AchievementEngine !== 'undefined') {
+      if (typeof AchievementEngine !== "undefined") {
         this.modules.achievementEngine = new AchievementEngine();
-        console.log('✅ AchievementEngine initialized');
+        console.log("✅ AchievementEngine initialized");
       }
-      
-      if (typeof ChartManager !== 'undefined' && typeof Chart !== 'undefined') {
+
+      if (typeof ChartManager !== "undefined" && typeof Chart !== "undefined") {
         this.modules.chartManager = new ChartManager();
-        console.log('✅ ChartManager initialized');
+        console.log("✅ ChartManager initialized");
       }
-      
-      if (typeof UIComponents !== 'undefined') {
+
+      if (typeof UIComponents !== "undefined") {
         this.modules.uiComponents = new UIComponents();
-        console.log('✅ UIComponents initialized');
+        console.log("✅ UIComponents initialized");
       }
-      
-      if (typeof Statistics !== 'undefined') {
+
+      if (typeof Statistics !== "undefined") {
         this.modules.statistics = new Statistics();
-        console.log('✅ Statistics initialized');
+        console.log("✅ Statistics initialized");
       }
-      
-      if (typeof FilterManager !== 'undefined') {
+
+      if (typeof FilterManager !== "undefined") {
         this.modules.filterManager = new FilterManager();
-        console.log('✅ FilterManager initialized');
+        console.log("✅ FilterManager initialized");
       }
-      
-      console.log('📦 Module initialization complete');
+
+      console.log("📦 Module initialization complete");
     } catch (error) {
-      console.error('⚠️ Non-critical module initialization failed:', error);
+      console.error("⚠️ Non-critical module initialization failed:", error);
       // Continue anyway - the app can work with reduced functionality
     }
   }
@@ -119,46 +118,46 @@ class PekkasPokalApp {
    * Setup event listeners
    */
   setupEventListeners() {
-    console.log('🎛️ Setting up event listeners...');
-    
+    console.log("🎛️ Setting up event listeners...");
+
     // Tab navigation
     this.setupTabNavigation();
-    
+
     // Filter controls
     this.setupFilterControls();
-    
+
     // Achievement categories
     this.setupAchievementFilters();
-    
+
     // Window events
-    window.addEventListener('resize', () => this.handleResize());
-    
-    console.log('🎛️ Event listeners setup complete');
+    window.addEventListener("resize", () => this.handleResize());
+
+    console.log("🎛️ Event listeners setup complete");
   }
 
   /**
    * Setup tab navigation
    */
   setupTabNavigation() {
-    const tabs = document.querySelectorAll('.nav-tab');
-    const contents = document.querySelectorAll('.tab-content');
+    const tabs = document.querySelectorAll(".nav-tab");
+    const contents = document.querySelectorAll(".tab-content");
 
-    tabs.forEach(tab => {
-      tab.addEventListener('click', (e) => {
+    tabs.forEach((tab) => {
+      tab.addEventListener("click", (e) => {
         e.preventDefault();
         const targetTab = tab.dataset.tab;
-        
+
         if (!targetTab) return;
-        
+
         // Update active states
-        tabs.forEach(t => t.classList.remove('active'));
-        contents.forEach(c => c.classList.remove('active'));
-        
-        tab.classList.add('active');
+        tabs.forEach((t) => t.classList.remove("active"));
+        contents.forEach((c) => c.classList.remove("active"));
+
+        tab.classList.add("active");
         const targetContent = document.getElementById(targetTab);
-        
+
         if (targetContent) {
-          targetContent.classList.add('active');
+          targetContent.classList.add("active");
           this.state.currentTab = targetTab;
           this.loadTabContent(targetTab);
         }
@@ -170,40 +169,71 @@ class PekkasPokalApp {
    * Setup filter controls
    */
   setupFilterControls() {
-    const competitorFilter = document.getElementById('competitor-filter');
-    const achievementCompetitorFilter = document.getElementById('achievement-competitor-filter');
-    const timeframeFilter = document.getElementById('timeframe-filter');
-    const competitionTypeFilter = document.getElementById('competition-type-filter');
-    const resetBtn = document.getElementById('reset-filters-btn');
+    const competitorFilter = document.getElementById("competitor-filter");
+    const achievementCompetitorFilter = document.getElementById(
+      "achievement-competitor-filter",
+    );
+    const timeframeFilter = document.getElementById("timeframe-filter");
+    const competitionTypeFilter = document.getElementById(
+      "competition-type-filter",
+    );
+    const resetBtn = document.getElementById("reset-filters-btn");
+
+    const updateSelectSize = () => {
+      const isDesktop = window.matchMedia("(min-width: 769px)").matches;
+      const size = isDesktop
+        ? Math.min(8, competitorFilter?.options.length || 8)
+        : 1;
+      [competitorFilter, achievementCompetitorFilter].forEach((select) => {
+        if (select) {
+          select.size = size;
+        }
+      });
+    };
+    this.updateSelectSize = updateSelectSize;
+    updateSelectSize();
+    window.addEventListener("resize", updateSelectSize);
 
     // Filter change handlers
-    [competitorFilter, achievementCompetitorFilter, timeframeFilter, competitionTypeFilter].forEach(filter => {
+    [
+      competitorFilter,
+      achievementCompetitorFilter,
+      timeframeFilter,
+      competitionTypeFilter,
+    ].forEach((filter) => {
       if (filter) {
-        filter.addEventListener('change', (e) => {
+        filter.addEventListener("change", (e) => {
           let filterType;
-          if (e.target.id === 'competitor-filter' || e.target.id === 'achievement-competitor-filter') {
-            filterType = 'competitor';
+          if (
+            e.target.id === "competitor-filter" ||
+            e.target.id === "achievement-competitor-filter"
+          ) {
+            filterType = "competitor";
 
             // Get selected values
-            let values = Array.from(e.target.selectedOptions).map(opt => opt.value);
-            if (values.length === 0 || values.includes('all')) {
-              values = ['all'];
+            let values = Array.from(e.target.selectedOptions).map(
+              (opt) => opt.value,
+            );
+            if (values.length === 0 || values.includes("all")) {
+              values = ["all"];
             }
 
             // Sync both competitor filters
             const syncSelect = (select) => {
               if (!select) return;
-              Array.from(select.options).forEach(opt => {
+              Array.from(select.options).forEach((opt) => {
                 opt.selected = values.includes(opt.value);
               });
             };
             syncSelect(competitorFilter);
             syncSelect(achievementCompetitorFilter);
 
-            this.state.filters[filterType] = values.includes('all') ? 'all' : values;
+            this.state.filters[filterType] = values.includes("all")
+              ? "all"
+              : values;
           } else {
             filterType = e.target.id
-              .replace('-filter', '')
+              .replace("-filter", "")
               .replace(/-([a-z])/g, (_, c) => c.toUpperCase());
             this.state.filters[filterType] = e.target.value;
           }
@@ -215,7 +245,7 @@ class PekkasPokalApp {
 
     // Reset filters
     if (resetBtn) {
-      resetBtn.addEventListener('click', () => {
+      resetBtn.addEventListener("click", () => {
         this.resetFilters();
       });
     }
@@ -225,13 +255,13 @@ class PekkasPokalApp {
    * Setup achievement filter buttons
    */
   setupAchievementFilters() {
-    document.addEventListener('click', (e) => {
-      if (e.target.classList.contains('category-filter')) {
-        document.querySelectorAll('.category-filter').forEach(btn => 
-          btn.classList.remove('active')
-        );
-        e.target.classList.add('active');
-        
+    document.addEventListener("click", (e) => {
+      if (e.target.classList.contains("category-filter")) {
+        document
+          .querySelectorAll(".category-filter")
+          .forEach((btn) => btn.classList.remove("active"));
+        e.target.classList.add("active");
+
         const category = e.target.dataset.category;
         if (this.modules.uiComponents) {
           this.modules.uiComponents.renderAchievementsGrid(category);
@@ -245,46 +275,54 @@ class PekkasPokalApp {
    */
   async loadData() {
     try {
-      console.log('📊 Loading competition data...');
-      
+      console.log("📊 Loading competition data...");
+
       if (this.modules.dataManager && this.modules.dataManager.loadCSVData) {
         // Try to load via DataManager
-        this.state.competitionData = await this.modules.dataManager.loadCSVData();
+        this.state.competitionData =
+          await this.modules.dataManager.loadCSVData();
       } else {
         // Use embedded data directly
-        console.log('Using embedded data directly');
+        console.log("Using embedded data directly");
         this.state.competitionData = this.getEmbeddedData();
       }
-      
-      if (!this.state.competitionData || !this.state.competitionData.competitions) {
-        throw new Error('Invalid data structure');
+
+      if (
+        !this.state.competitionData ||
+        !this.state.competitionData.competitions
+      ) {
+        throw new Error("Invalid data structure");
       }
-      
-      console.log(`📊 Data loaded: ${this.state.competitionData.competitions.length} competitions`);
-      
+
+      console.log(
+        `📊 Data loaded: ${this.state.competitionData.competitions.length} competitions`,
+      );
+
       // Calculate achievements if engine is available
-      if (this.modules.achievementEngine && this.modules.achievementEngine.calculateAllAchievements) {
+      if (
+        this.modules.achievementEngine &&
+        this.modules.achievementEngine.calculateAllAchievements
+      ) {
         try {
-          this.state.competitionData.participantAchievements = 
+          this.state.competitionData.participantAchievements =
             this.modules.achievementEngine.calculateAllAchievements(
               this.state.competitionData.competitions,
-              this.state.competitionData.participants
+              this.state.competitionData.participants,
             );
         } catch (e) {
-          console.warn('Achievement calculation failed:', e);
+          console.warn("Achievement calculation failed:", e);
           this.state.competitionData.participantAchievements = {};
         }
       } else {
         this.state.competitionData.participantAchievements = {};
       }
-      
+
       // Populate filter options
       this.populateFilters();
-      
     } catch (error) {
-      console.error('❌ Failed to load data:', error);
+      console.error("❌ Failed to load data:", error);
       // Use embedded data as final fallback
-      console.log('Using embedded data as final fallback...');
+      console.log("Using embedded data as final fallback...");
       this.state.competitionData = this.getEmbeddedData();
       this.populateFilters();
     }
@@ -310,32 +348,32 @@ class PekkasPokalApp {
 2023,Fäkting,Stockholm,Viktor Jones,Mikael Hägglund,,3,10,1,,,2,,9,4,-,-,-
 2024-08-17,Fisketävling,Själevad,Tobias Lundqvist,Per Olsson,7,10,4,9,1,2,12,5,3,11,8,6,-
 2025-08-16,Flipper,Eskilstuna/Västerås,Viktor Jones,Mikael Hägglund,2,7,1,11,10,5,9,12,3,6,4,8,-`;
-    
+
     // Simple parsing without dependencies
-    const lines = csvContent.split('\n');
-    const headers = lines[0].split(',');
+    const lines = csvContent.split("\n");
+    const headers = lines[0].split(",");
     const participantNames = headers.slice(5);
-    
+
     const participants = participantNames.map((name, i) => ({
       id: `p${i + 1}`,
       name: name.trim(),
-      nickname: name.trim()
+      nickname: name.trim(),
     }));
-    
+
     const competitions = [];
     for (let i = 1; i < lines.length; i++) {
-      const values = lines[i].split(',');
+      const values = lines[i].split(",");
       const year = parseInt(values[0]);
       const name = values[1];
-      
+
       if (!year || !name) continue;
-      
+
       const scores = {};
       let winner = null;
-      
+
       for (let j = 0; j < participantNames.length; j++) {
         const score = values[j + 5];
-        if (score && score !== '-' && score !== '') {
+        if (score && score !== "-" && score !== "") {
           const position = parseInt(score);
           if (!isNaN(position)) {
             scores[`p${j + 1}`] = position;
@@ -345,27 +383,27 @@ class PekkasPokalApp {
           }
         }
       }
-      
+
       competitions.push({
         id: `c${competitions.length + 1}`,
         year: year,
         name: name,
-        location: values[2] || '',
+        location: values[2] || "",
         winner: winner,
         scores: scores,
-        arranger3rd: values[3] || '',
-        arrangerSecondLast: values[4] || '',
-        participantCount: Object.keys(scores).length
+        arranger3rd: values[3] || "",
+        arrangerSecondLast: values[4] || "",
+        participantCount: Object.keys(scores).length,
       });
     }
-    
+
     competitions.sort((a, b) => b.year - a.year);
-    
+
     return {
       participants,
       competitions,
       participantAchievements: {},
-      initialized: true
+      initialized: true,
     };
   }
 
@@ -374,32 +412,41 @@ class PekkasPokalApp {
    */
   populateFilters() {
     if (!this.state.competitionData) return;
-    
+
     // Competitor filters
-    const competitorFilter = document.getElementById('competitor-filter');
-    const achievementCompetitorFilter = document.getElementById('achievement-competitor-filter');
-    [competitorFilter, achievementCompetitorFilter].forEach(filter => {
+    const competitorFilter = document.getElementById("competitor-filter");
+    const achievementCompetitorFilter = document.getElementById(
+      "achievement-competitor-filter",
+    );
+    [competitorFilter, achievementCompetitorFilter].forEach((filter) => {
       if (filter) {
-        filter.innerHTML = '<option value="all" selected>Alla Deltagare</option>';
+        filter.innerHTML =
+          '<option value="all" selected>Alla Deltagare</option>';
       }
     });
-    this.state.competitionData.participants.forEach(p => {
-      const option = document.createElement('option');
+    this.state.competitionData.participants.forEach((p) => {
+      const option = document.createElement("option");
       option.value = p.id;
       option.textContent = p.name;
-      if (competitorFilter) competitorFilter.appendChild(option.cloneNode(true));
-      if (achievementCompetitorFilter) achievementCompetitorFilter.appendChild(option);
+      if (competitorFilter)
+        competitorFilter.appendChild(option.cloneNode(true));
+      if (achievementCompetitorFilter)
+        achievementCompetitorFilter.appendChild(option);
     });
 
+    if (this.updateSelectSize) {
+      this.updateSelectSize();
+    }
+
     // Competition type filter
-    const competitionTypes = [...new Set(
-      this.state.competitionData.competitions.map(c => c.name)
-    )];
-    const typeFilter = document.getElementById('competition-type-filter');
+    const competitionTypes = [
+      ...new Set(this.state.competitionData.competitions.map((c) => c.name)),
+    ];
+    const typeFilter = document.getElementById("competition-type-filter");
     if (typeFilter) {
       typeFilter.innerHTML = '<option value="all">Alla Tävlingar</option>';
-      competitionTypes.forEach(type => {
-        const option = document.createElement('option');
+      competitionTypes.forEach((type) => {
+        const option = document.createElement("option");
         option.value = type;
         option.textContent = type;
         typeFilter.appendChild(option);
@@ -415,15 +462,15 @@ class PekkasPokalApp {
       return;
     }
 
-    console.log('🎨 Rendering application...');
+    console.log("🎨 Rendering application...");
 
     // Render dashboard by default
-    this.loadTabContent('dashboard');
-    
+    this.loadTabContent("dashboard");
+
     // Update year range display
     this.updateYearRange();
-    
-    console.log('✅ Application render complete');
+
+    console.log("✅ Application render complete");
   }
 
   /**
@@ -431,24 +478,24 @@ class PekkasPokalApp {
    */
   loadTabContent(tabName) {
     console.log(`📄 Loading content for tab: ${tabName}`);
-    
+
     if (!this.state.competitionData) {
-      console.warn('No data available for tab content');
+      console.warn("No data available for tab content");
       return;
     }
 
     try {
       switch (tabName) {
-        case 'dashboard':
+        case "dashboard":
           this.loadDashboard();
           break;
-        case 'medals':
+        case "medals":
           this.loadMedalTally();
           break;
-        case 'achievements':
+        case "achievements":
           this.loadAchievements();
           break;
-        case 'statistics':
+        case "statistics":
           this.loadStatistics();
           break;
       }
@@ -461,18 +508,18 @@ class PekkasPokalApp {
    * Load dashboard content
    */
   loadDashboard() {
-    console.log('📊 Loading dashboard...');
+    console.log("📊 Loading dashboard...");
     const data = this.state.competitionData;
-    
+
     // Update stats cards
     this.updateStatsCards(data);
-    
+
     // Load fun stats
     if (this.modules.statistics && this.modules.uiComponents) {
       const funStats = this.modules.statistics.calculateFunStats(data);
       this.modules.uiComponents.renderFunStats(funStats);
     }
-    
+
     // Create charts
     if (this.modules.chartManager) {
       this.modules.chartManager.createWinsChart(data);
@@ -491,29 +538,33 @@ class PekkasPokalApp {
   updateStatsCards(data) {
     // Total competitions
     const totalComps = data.competitions.length;
-    this.updateElement('total-competitions', totalComps);
-    this.updateElement('comp-trend', `${totalComps} totalt`);
-    
+    this.updateElement("total-competitions", totalComps);
+    this.updateElement("comp-trend", `${totalComps} totalt`);
+
     // Total participants
     const totalParticipants = data.participants.length;
-    this.updateElement('total-participants', totalParticipants);
-    
+    this.updateElement("total-participants", totalParticipants);
+
     // Calculate winner stats
     if (this.modules.statistics) {
-      const winCounts = this.modules.statistics.calculateWinCounts(data.competitions);
-      const topWinner = Object.entries(winCounts).sort((a, b) => b[1] - a[1])[0];
-      
+      const winCounts = this.modules.statistics.calculateWinCounts(
+        data.competitions,
+      );
+      const topWinner = Object.entries(winCounts).sort(
+        (a, b) => b[1] - a[1],
+      )[0];
+
       if (topWinner) {
-        this.updateElement('most-wins', topWinner[0]);
-        this.updateElement('wins-count', `${topWinner[1]} vinster`);
+        this.updateElement("most-wins", topWinner[0]);
+        this.updateElement("wins-count", `${topWinner[1]} vinster`);
       }
     }
-    
+
     // Latest winner
     const latestComp = data.competitions[0];
     if (latestComp && latestComp.winner) {
-      this.updateElement('current-champion', latestComp.winner);
-      this.updateElement('champ-comp', `${latestComp.year} ${latestComp.name}`);
+      this.updateElement("current-champion", latestComp.winner);
+      this.updateElement("champ-comp", `${latestComp.year} ${latestComp.name}`);
     }
   }
 
@@ -521,18 +572,18 @@ class PekkasPokalApp {
    * Render upcoming event and countdown
    */
   renderUpcomingEvent(data) {
-    const nameEl = document.getElementById('next-event-name');
-    const countdownEl = document.getElementById('next-event-countdown');
+    const nameEl = document.getElementById("next-event-name");
+    const countdownEl = document.getElementById("next-event-countdown");
     if (!nameEl || !countdownEl) return;
 
     const now = new Date();
     const upcoming = data.competitions
-      .filter(c => c.date && c.date > now)
+      .filter((c) => c.date && c.date > now)
       .sort((a, b) => a.date - b.date)[0];
 
     if (!upcoming) {
-      nameEl.textContent = 'Ingen planerad';
-      countdownEl.textContent = '';
+      nameEl.textContent = "Ingen planerad";
+      countdownEl.textContent = "";
       return;
     }
 
@@ -541,11 +592,13 @@ class PekkasPokalApp {
     const updateCountdown = () => {
       const diff = upcoming.date - new Date();
       if (diff <= 0) {
-        countdownEl.textContent = 'Pågår!';
+        countdownEl.textContent = "Pågår!";
         return;
       }
       const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-      const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+      const hours = Math.floor(
+        (diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60),
+      );
       countdownEl.textContent = `${days}d ${hours}h`;
     };
 
@@ -557,7 +610,7 @@ class PekkasPokalApp {
    * Highlight recent achievements
    */
   renderAchievementsHighlight(data) {
-    const list = document.getElementById('recent-achievements-list');
+    const list = document.getElementById("recent-achievements-list");
     if (!list) return;
 
     const latestComp = data.competitions[0];
@@ -568,19 +621,19 @@ class PekkasPokalApp {
       achievements = achievementsData[latestComp.winner] || [];
     }
 
-    list.innerHTML = '';
-    achievements.slice(0, 3).forEach(achId => {
-      const def = window.ACHIEVEMENT_DEFINITIONS?.find(a => a.id === achId);
+    list.innerHTML = "";
+    achievements.slice(0, 3).forEach((achId) => {
+      const def = window.ACHIEVEMENT_DEFINITIONS?.find((a) => a.id === achId);
       if (def) {
-        const li = document.createElement('li');
+        const li = document.createElement("li");
         li.textContent = `${def.icon} ${def.name}`;
         list.appendChild(li);
       }
     });
 
     if (list.childElementCount === 0) {
-      const li = document.createElement('li');
-      li.textContent = 'Inga nya achievements';
+      const li = document.createElement("li");
+      li.textContent = "Inga nya achievements";
       list.appendChild(li);
     }
   }
@@ -589,10 +642,10 @@ class PekkasPokalApp {
    * Render record book section
    */
   renderRecords(data) {
-    const list = document.getElementById('record-list');
+    const list = document.getElementById("record-list");
     if (!list || !this.modules.statistics) return;
 
-    list.innerHTML = '';
+    list.innerHTML = "";
 
     // Longest winning streak
     const comps = [...data.competitions].sort((a, b) => a.year - b.year);
@@ -601,7 +654,7 @@ class PekkasPokalApp {
     let currentWinner = null;
     let currentStreak = 0;
 
-    comps.forEach(comp => {
+    comps.forEach((comp) => {
       if (comp.winner) {
         if (comp.winner === currentWinner) {
           currentStreak++;
@@ -620,33 +673,37 @@ class PekkasPokalApp {
     });
 
     if (streakHolder) {
-      const li = document.createElement('li');
+      const li = document.createElement("li");
       li.textContent = `Längsta segersvit: ${streakHolder} (${bestStreak})`;
       list.appendChild(li);
     }
 
     // Most participants in a year
-    const mostPart = comps.reduce((max, comp) =>
-      comp.participantCount > (max?.participantCount || 0) ? comp : max,
-    null);
+    const mostPart = comps.reduce(
+      (max, comp) =>
+        comp.participantCount > (max?.participantCount || 0) ? comp : max,
+      null,
+    );
     if (mostPart) {
-      const li = document.createElement('li');
+      const li = document.createElement("li");
       li.textContent = `Flest deltagare: ${mostPart.year} (${mostPart.participantCount})`;
       list.appendChild(li);
     }
 
     // Most wins overall
-    const winCounts = this.modules.statistics.calculateWinCounts(data.competitions);
+    const winCounts = this.modules.statistics.calculateWinCounts(
+      data.competitions,
+    );
     const topWinner = Object.entries(winCounts).sort((a, b) => b[1] - a[1])[0];
     if (topWinner) {
-      const li = document.createElement('li');
+      const li = document.createElement("li");
       li.textContent = `Flest vinster: ${topWinner[0]} (${topWinner[1]})`;
       list.appendChild(li);
     }
 
     if (list.childElementCount === 0) {
-      const li = document.createElement('li');
-      li.textContent = 'Inga rekord';
+      const li = document.createElement("li");
+      li.textContent = "Inga rekord";
       list.appendChild(li);
     }
   }
@@ -655,14 +712,14 @@ class PekkasPokalApp {
    * Load medal tally
    */
   loadMedalTally() {
-    console.log('🥇 Loading medal tally...');
+    console.log("🥇 Loading medal tally...");
     const data = this.state.competitionData;
-    
+
     if (this.modules.statistics && this.modules.uiComponents) {
       const medalCounts = this.modules.statistics.calculateMedalCounts(data);
       this.modules.uiComponents.renderMedalTally(medalCounts);
     }
-    
+
     if (this.modules.chartManager && this.modules.statistics) {
       const medalCounts = this.modules.statistics.calculateMedalCounts(data);
       this.modules.chartManager.createMedalChart(medalCounts);
@@ -673,13 +730,13 @@ class PekkasPokalApp {
    * Load achievements
    */
   loadAchievements() {
-    console.log('🏆 Loading achievements...');
+    console.log("🏆 Loading achievements...");
     const participantAchievements = this.getFilteredParticipantAchievements();
 
     if (this.modules.uiComponents) {
       this.modules.uiComponents.updateAchievementStats(participantAchievements);
       this.modules.uiComponents.renderParticipantCards(participantAchievements);
-      this.modules.uiComponents.renderAchievementsGrid('all');
+      this.modules.uiComponents.renderAchievementsGrid("all");
     }
   }
 
@@ -687,18 +744,24 @@ class PekkasPokalApp {
    * Load statistics
    */
   loadStatistics() {
-    console.log('📈 Loading statistics...');
-    
-    if (this.modules.filterManager && this.modules.uiComponents && this.modules.chartManager) {
+    console.log("📈 Loading statistics...");
+
+    if (
+      this.modules.filterManager &&
+      this.modules.uiComponents &&
+      this.modules.chartManager
+    ) {
       const filteredData = this.modules.filterManager.applyFilters(
         this.state.competitionData,
-        this.state.filters
+        this.state.filters,
       );
       // FilterManager returns an object containing competitions, participants and the
       // original data. The statistics components only need the competitions array,
       // so pass that to avoid runtime errors when iterating over the result.
       this.modules.uiComponents.updateStatisticsView(filteredData.competitions);
-      this.modules.chartManager.updateStatisticsCharts(filteredData.competitions);
+      this.modules.chartManager.updateStatisticsCharts(
+        filteredData.competitions,
+      );
     }
   }
 
@@ -706,9 +769,9 @@ class PekkasPokalApp {
    * Apply current filters
    */
   applyFilters() {
-    if (this.state.currentTab === 'statistics') {
+    if (this.state.currentTab === "statistics") {
       this.loadStatistics();
-    } else if (this.state.currentTab === 'achievements') {
+    } else if (this.state.currentTab === "achievements") {
       this.loadAchievements();
     }
   }
@@ -718,17 +781,17 @@ class PekkasPokalApp {
    */
   resetFilters() {
     this.state.filters = {
-      competitor: 'all',
-      timeframe: 'all',
-      competitionType: 'all'
+      competitor: "all",
+      timeframe: "all",
+      competitionType: "all",
     };
 
     // Update UI
-    this.updateElement('competitor-filter', ['all'], 'value');
-    this.updateElement('achievement-competitor-filter', ['all'], 'value');
-    this.updateElement('timeframe-filter', 'all', 'value');
-    this.updateElement('competition-type-filter', 'all', 'value');
-    
+    this.updateElement("competitor-filter", ["all"], "value");
+    this.updateElement("achievement-competitor-filter", ["all"], "value");
+    this.updateElement("timeframe-filter", "all", "value");
+    this.updateElement("competition-type-filter", "all", "value");
+
     this.applyFilters();
   }
 
@@ -738,11 +801,11 @@ class PekkasPokalApp {
   updateYearRange() {
     const data = this.state.competitionData;
     if (data && data.competitions.length > 0) {
-      const years = data.competitions.map(c => c.year).filter(y => y);
+      const years = data.competitions.map((c) => c.year).filter((y) => y);
       const minYear = Math.min(...years);
       const maxYear = Math.max(...years);
-      
-      this.updateElement('year-range', `${minYear}-${maxYear}`);
+
+      this.updateElement("year-range", `${minYear}-${maxYear}`);
     }
   }
 
@@ -762,7 +825,7 @@ class PekkasPokalApp {
    * Show error message
    */
   showError(message) {
-    const loadingScreen = document.getElementById('loading-screen');
+    const loadingScreen = document.getElementById("loading-screen");
     if (loadingScreen) {
       loadingScreen.innerHTML = `
         <div style="text-align: center; padding: 2rem;">
@@ -787,14 +850,14 @@ class PekkasPokalApp {
 
   /**
    * Utility function to update element content
-  */
-  updateElement(id, content, property = 'textContent') {
+   */
+  updateElement(id, content, property = "textContent") {
     const element = document.getElementById(id);
     if (!element) return;
 
-    if (property === 'value' && element.multiple) {
+    if (property === "value" && element.multiple) {
       const values = Array.isArray(content) ? content : [content];
-      Array.from(element.options).forEach(opt => {
+      Array.from(element.options).forEach((opt) => {
         opt.selected = values.includes(opt.value);
       });
     } else {
@@ -810,14 +873,15 @@ class PekkasPokalApp {
     if (!data || !data.participantAchievements) return {};
 
     const selected = this.state.filters.competitor;
-    if (selected === 'all') return data.participantAchievements;
+    if (selected === "all") return data.participantAchievements;
 
     const ids = Array.isArray(selected) ? selected : [selected];
     const result = {};
-    ids.forEach(id => {
-      const participant = data.participants.find(p => p.id === id);
+    ids.forEach((id) => {
+      const participant = data.participants.find((p) => p.id === id);
       if (participant) {
-        result[participant.name] = data.participantAchievements[participant.name] || [];
+        result[participant.name] =
+          data.participantAchievements[participant.name] || [];
       }
     });
     return result;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -78,7 +78,7 @@
 }
 
 .nav-tab::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: -100%;
@@ -116,7 +116,7 @@
 }
 
 .stat-card::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: 0;
@@ -193,7 +193,7 @@
 }
 
 .medal-tally::before {
-  content: '🏅';
+  content: "🏅";
   position: absolute;
   right: -20px;
   top: -20px;
@@ -245,7 +245,7 @@
   text-align: center;
 }
 
-.medal-position.first { 
+.medal-position.first {
   background: var(--gold);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -289,17 +289,17 @@
 
 .medal-count.gold {
   background: rgba(255, 215, 0, 0.2);
-  color: #FFD700;
+  color: #ffd700;
 }
 
 .medal-count.silver {
   background: rgba(192, 192, 192, 0.2);
-  color: #C0C0C0;
+  color: #c0c0c0;
 }
 
 .medal-count.bronze {
   background: rgba(205, 127, 50, 0.2);
-  color: #CD7F32;
+  color: #cd7f32;
 }
 
 .medal-total {
@@ -380,7 +380,7 @@
 }
 
 .participant-card::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: 0;
@@ -568,14 +568,22 @@
 }
 
 .achievement.legendary {
-  background: linear-gradient(135deg, rgba(255, 215, 0, 0.1), rgba(255, 165, 0, 0.1));
+  background: linear-gradient(
+    135deg,
+    rgba(255, 215, 0, 0.1),
+    rgba(255, 165, 0, 0.1)
+  );
   border-color: gold;
   animation: shimmer 3s infinite;
 }
 
 .achievement.mythic {
-  background: linear-gradient(135deg, rgba(255, 0, 255, 0.1), rgba(0, 255, 255, 0.1));
-  border-color: #FF00FF;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 0, 255, 0.1),
+    rgba(0, 255, 255, 0.1)
+  );
+  border-color: #ff00ff;
   animation: rainbow 5s linear infinite;
 }
 
@@ -590,11 +598,22 @@
   text-transform: uppercase;
 }
 
-.rarity-common { background: #808080; }
-.rarity-rare { background: #0080FF; }
-.rarity-epic { background: #8B00FF; }
-.rarity-legendary { background: #FFD700; color: #000; }
-.rarity-mythic { background: var(--mythic-gradient); }
+.rarity-common {
+  background: #808080;
+}
+.rarity-rare {
+  background: #0080ff;
+}
+.rarity-epic {
+  background: #8b00ff;
+}
+.rarity-legendary {
+  background: #ffd700;
+  color: #000;
+}
+.rarity-mythic {
+  background: var(--mythic-gradient);
+}
 
 .achievement-holders {
   margin-top: var(--spacing-sm);
@@ -650,7 +669,7 @@
 }
 
 .competitor-card::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: 0;
@@ -714,7 +733,11 @@
 
 /* ===== FUN STATS ===== */
 .fun-stats {
-  background: linear-gradient(135deg, rgba(102, 126, 234, 0.1), rgba(240, 147, 251, 0.1));
+  background: linear-gradient(
+    135deg,
+    rgba(102, 126, 234, 0.1),
+    rgba(240, 147, 251, 0.1)
+  );
   border-radius: var(--radius-lg);
   padding: var(--spacing-lg);
   margin: var(--spacing-xl) 0;
@@ -789,6 +812,12 @@
   cursor: pointer;
   transition: all var(--transition-normal);
   min-width: 150px;
+}
+
+@media (min-width: 769px) {
+  .filter-select[multiple] {
+    min-width: 220px;
+  }
 }
 
 .filter-select option {


### PR DESCRIPTION
## Summary
- Increase default width of multi-select filters on desktop for easier reading.
- Dynamically expand competitor filters to show multiple options on wider screens.

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: Cannot read config file: .eslintrc.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a786dbd4548329941bfe56de159b73