### PR TITLE
Improve mobile header and tab navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
     </style>
 
     <!-- Header -->
-    <header class="header">
+    <header class="header sticky-header">
       <div class="header-content">
         <div class="logo">
           <span class="trophy-logo">🏆</span>
@@ -140,7 +140,7 @@
     </header>
 
     <!-- Navigation -->
-    <nav class="nav-tabs">
+    <nav class="nav-tabs sticky-nav">
       <button class="nav-tab active" data-tab="dashboard">
         <span>📊</span> Dashboard
       </button>

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -64,19 +64,25 @@
 
   /* Navigation adjustments */
   .nav-tabs {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
     padding: var(--spacing-sm);
     gap: var(--spacing-sm);
-    justify-content: flex-start;
+    justify-content: center;
+    overflow-x: visible;
   }
 
   .nav-tab {
-    padding: var(--spacing-xs) var(--spacing-sm);
-    font-size: var(--text-xs);
+    padding: var(--spacing-sm);
+    font-size: var(--text-sm);
+    text-align: center;
     min-width: auto;
   }
 
   .nav-tab span {
-    margin-right: var(--spacing-xs);
+    display: block;
+    margin: 0 0 var(--spacing-xs) 0;
+    font-size: var(--text-lg);
   }
 
   /* Grid system adjustments */


### PR DESCRIPTION
## Summary
- make header and navigation sticky
- redesign nav tabs for better mobile layout

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: `.eslintrc.js` treated as ESM)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68a792b4dc6c8329a19402a99c0f758c