### PR TITLE
refactor: streamline mobile header layout

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -131,6 +131,8 @@ class PekkasPokalApp {
 
     // Window events
     window.addEventListener("resize", () => this.handleResize());
+    // Set initial header height for sticky nav
+    this.updateHeaderHeight();
 
     console.log("🎛️ Event listeners setup complete");
   }
@@ -772,11 +774,26 @@ class PekkasPokalApp {
   }
 
   /**
+   * Update CSS variable for header height to keep nav positioning in sync
+   */
+  updateHeaderHeight() {
+    const header = document.querySelector(".header");
+    if (header) {
+      const height = header.offsetHeight;
+      document.documentElement.style.setProperty(
+        "--header-height",
+        `${height}px`,
+      );
+    }
+  }
+
+  /**
    * Handle window resize
    */
   handleResize() {
     clearTimeout(this.resizeTimeout);
     this.resizeTimeout = setTimeout(() => {
+      this.updateHeaderHeight();
       if (this.modules.chartManager) {
         this.modules.chartManager.handleResize();
       }

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -35,30 +35,32 @@
 
   /* Header modifications */
   .header {
-    padding: var(--spacing-md);
+    padding: var(--spacing-sm) var(--spacing-md);
   }
 
   .header-content {
-    flex-direction: column;
-    gap: var(--spacing-md);
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-sm);
     text-align: center;
   }
 
   .logo {
-    flex-direction: column;
-    gap: var(--spacing-sm);
+    flex-direction: row;
+    gap: var(--spacing-xs);
   }
 
   .trophy-logo {
-    font-size: 2rem;
+    font-size: 1.5rem;
   }
 
   .logo h1 {
-    font-size: var(--text-2xl);
+    font-size: var(--text-xl);
   }
 
   .year-range {
-    margin-left: 0;
+    margin-left: var(--spacing-xs);
     font-size: var(--text-xs);
   }
 


### PR DESCRIPTION
## Summary
- tighten mobile header spacing and reduce logo sizes
- dynamically sync sticky nav offset to header height

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a79507c5d48329b7797556b8ecd4f9