### PR TITLE
Fix mobile tab navigation responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,19 +140,21 @@
     </header>
 
     <!-- Navigation -->
-    <nav class="nav-tabs sticky-nav">
-      <button class="nav-tab active" data-tab="dashboard">
-        <span>📊</span> Dashboard
-      </button>
-      <button class="nav-tab" data-tab="medals">
-        <span>🥇</span> Medaljliga
-      </button>
-      <button class="nav-tab" data-tab="achievements">
-        <span>🎖️</span> Achievements
-      </button>
-      <button class="nav-tab" data-tab="statistics">
-        <span>📈</span> Statistik
-      </button>
+    <nav class="sticky-nav">
+      <div class="nav-tabs">
+        <button class="nav-tab active" data-tab="dashboard">
+          <span>📊</span> Dashboard
+        </button>
+        <button class="nav-tab" data-tab="medals">
+          <span>🥇</span> Medaljliga
+        </button>
+        <button class="nav-tab" data-tab="achievements">
+          <span>🎖️</span> Achievements
+        </button>
+        <button class="nav-tab" data-tab="statistics">
+          <span>📈</span> Statistik
+        </button>
+      </div>
     </nav>
 
     <!-- Main Container -->

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -241,79 +241,189 @@
 /* ===== SPACING UTILITIES ===== */
 
 /* Margin utilities */
-.mt-0 { margin-top: 0; }
-.mt-sm { margin-top: var(--spacing-sm); }
-.mt-md { margin-top: var(--spacing-md); }
-.mt-lg { margin-top: var(--spacing-lg); }
-.mt-xl { margin-top: var(--spacing-xl); }
+.mt-0 {
+  margin-top: 0;
+}
+.mt-sm {
+  margin-top: var(--spacing-sm);
+}
+.mt-md {
+  margin-top: var(--spacing-md);
+}
+.mt-lg {
+  margin-top: var(--spacing-lg);
+}
+.mt-xl {
+  margin-top: var(--spacing-xl);
+}
 
-.mb-0 { margin-bottom: 0; }
-.mb-sm { margin-bottom: var(--spacing-sm); }
-.mb-md { margin-bottom: var(--spacing-md); }
-.mb-lg { margin-bottom: var(--spacing-lg); }
-.mb-xl { margin-bottom: var(--spacing-xl); }
+.mb-0 {
+  margin-bottom: 0;
+}
+.mb-sm {
+  margin-bottom: var(--spacing-sm);
+}
+.mb-md {
+  margin-bottom: var(--spacing-md);
+}
+.mb-lg {
+  margin-bottom: var(--spacing-lg);
+}
+.mb-xl {
+  margin-bottom: var(--spacing-xl);
+}
 
-.ml-0 { margin-left: 0; }
-.ml-sm { margin-left: var(--spacing-sm); }
-.ml-md { margin-left: var(--spacing-md); }
-.ml-lg { margin-left: var(--spacing-lg); }
-.ml-auto { margin-left: auto; }
+.ml-0 {
+  margin-left: 0;
+}
+.ml-sm {
+  margin-left: var(--spacing-sm);
+}
+.ml-md {
+  margin-left: var(--spacing-md);
+}
+.ml-lg {
+  margin-left: var(--spacing-lg);
+}
+.ml-auto {
+  margin-left: auto;
+}
 
-.mr-0 { margin-right: 0; }
-.mr-sm { margin-right: var(--spacing-sm); }
-.mr-md { margin-right: var(--spacing-md); }
-.mr-lg { margin-right: var(--spacing-lg); }
-.mr-auto { margin-right: auto; }
+.mr-0 {
+  margin-right: 0;
+}
+.mr-sm {
+  margin-right: var(--spacing-sm);
+}
+.mr-md {
+  margin-right: var(--spacing-md);
+}
+.mr-lg {
+  margin-right: var(--spacing-lg);
+}
+.mr-auto {
+  margin-right: auto;
+}
 
 /* Padding utilities */
-.pt-0 { padding-top: 0; }
-.pt-sm { padding-top: var(--spacing-sm); }
-.pt-md { padding-top: var(--spacing-md); }
-.pt-lg { padding-top: var(--spacing-lg); }
+.pt-0 {
+  padding-top: 0;
+}
+.pt-sm {
+  padding-top: var(--spacing-sm);
+}
+.pt-md {
+  padding-top: var(--spacing-md);
+}
+.pt-lg {
+  padding-top: var(--spacing-lg);
+}
 
-.pb-0 { padding-bottom: 0; }
-.pb-sm { padding-bottom: var(--spacing-sm); }
-.pb-md { padding-bottom: var(--spacing-md); }
-.pb-lg { padding-bottom: var(--spacing-lg); }
+.pb-0 {
+  padding-bottom: 0;
+}
+.pb-sm {
+  padding-bottom: var(--spacing-sm);
+}
+.pb-md {
+  padding-bottom: var(--spacing-md);
+}
+.pb-lg {
+  padding-bottom: var(--spacing-lg);
+}
 
-.pl-0 { padding-left: 0; }
-.pl-sm { padding-left: var(--spacing-sm); }
-.pl-md { padding-left: var(--spacing-md); }
-.pl-lg { padding-left: var(--spacing-lg); }
+.pl-0 {
+  padding-left: 0;
+}
+.pl-sm {
+  padding-left: var(--spacing-sm);
+}
+.pl-md {
+  padding-left: var(--spacing-md);
+}
+.pl-lg {
+  padding-left: var(--spacing-lg);
+}
 
-.pr-0 { padding-right: 0; }
-.pr-sm { padding-right: var(--spacing-sm); }
-.pr-md { padding-right: var(--spacing-md); }
-.pr-lg { padding-right: var(--spacing-lg); }
+.pr-0 {
+  padding-right: 0;
+}
+.pr-sm {
+  padding-right: var(--spacing-sm);
+}
+.pr-md {
+  padding-right: var(--spacing-md);
+}
+.pr-lg {
+  padding-right: var(--spacing-lg);
+}
 
 /* ===== POSITIONING ===== */
 
-.relative { position: relative; }
-.absolute { position: absolute; }
-.fixed { position: fixed; }
-.sticky { position: sticky; }
+.relative {
+  position: relative;
+}
+.absolute {
+  position: absolute;
+}
+.fixed {
+  position: fixed;
+}
+.sticky {
+  position: sticky;
+}
 
 /* Common positioning */
-.top-0 { top: 0; }
-.bottom-0 { bottom: 0; }
-.left-0 { left: 0; }
-.right-0 { right: 0; }
+.top-0 {
+  top: 0;
+}
+.bottom-0 {
+  bottom: 0;
+}
+.left-0 {
+  left: 0;
+}
+.right-0 {
+  right: 0;
+}
 
 /* Z-index utilities */
-.z-auto { z-index: auto; }
-.z-0 { z-index: 0; }
-.z-10 { z-index: 10; }
-.z-20 { z-index: 20; }
-.z-30 { z-index: 30; }
-.z-40 { z-index: 40; }
-.z-50 { z-index: 50; }
+.z-auto {
+  z-index: auto;
+}
+.z-0 {
+  z-index: 0;
+}
+.z-10 {
+  z-index: 10;
+}
+.z-20 {
+  z-index: 20;
+}
+.z-30 {
+  z-index: 30;
+}
+.z-40 {
+  z-index: 40;
+}
+.z-50 {
+  z-index: 50;
+}
 
 /* ===== OVERFLOW HANDLING ===== */
 
-.overflow-hidden { overflow: hidden; }
-.overflow-auto { overflow: auto; }
-.overflow-x-auto { overflow-x: auto; }
-.overflow-y-auto { overflow-y: auto; }
+.overflow-hidden {
+  overflow: hidden;
+}
+.overflow-auto {
+  overflow: auto;
+}
+.overflow-x-auto {
+  overflow-x: auto;
+}
+.overflow-y-auto {
+  overflow-y: auto;
+}
 
 /* Scrollable content */
 .scrollable {
@@ -337,12 +447,22 @@
 
 /* ===== VISIBILITY ===== */
 
-.hidden { display: none; }
-.visible { display: block; }
+.hidden {
+  display: none;
+}
+.visible {
+  display: block;
+}
 
-.opacity-0 { opacity: 0; }
-.opacity-50 { opacity: 0.5; }
-.opacity-100 { opacity: 1; }
+.opacity-0 {
+  opacity: 0;
+}
+.opacity-50 {
+  opacity: 0.5;
+}
+.opacity-100 {
+  opacity: 1;
+}
 
 /* ===== ASPECT RATIOS ===== */
 
@@ -383,7 +503,7 @@
     max-width: none;
     padding: 1rem;
   }
-  
+
   .dashboard-grid,
   .participant-cards,
   .achievements-grid,
@@ -391,16 +511,16 @@
     grid-template-columns: repeat(2, 1fr);
     gap: 1rem;
   }
-  
+
   .charts-grid {
     grid-template-columns: 1fr;
   }
-  
+
   .chart-container {
     height: 300px;
     page-break-inside: avoid;
   }
-  
+
   .participant-card,
   .stat-card,
   .achievement {
@@ -420,6 +540,6 @@
 .sticky-nav {
   position: sticky;
   top: var(--header-height, 80px);
-  z-index: calc(var(--z-sticky) - 1);
+  z-index: var(--z-sticky);
   background: var(--bg-dark);
 }

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -66,19 +66,19 @@
 
   /* Navigation adjustments */
   .nav-tabs {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    display: flex;
     padding: var(--spacing-sm);
     gap: var(--spacing-sm);
-    justify-content: center;
-    overflow-x: visible;
+    justify-content: flex-start;
+    overflow-x: auto;
   }
 
   .nav-tab {
     padding: var(--spacing-sm);
     font-size: var(--text-sm);
     text-align: center;
-    min-width: auto;
+    flex: 0 0 auto;
+    min-width: max-content;
   }
 
   .nav-tab span {


### PR DESCRIPTION
## Summary
- Keep tab bar visible by separating sticky behavior from overflow
- Simplify small-screen navigation to a horizontally scrollable flex layout
- Raise sticky nav z-index so it doesn't vanish under content

## Testing
- `npm test` *(no tests found)*
- `npm run lint` *(fails: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a796725f5c8329b63b7b8f8c9a342c