### PR TITLE
Fix mobile medal layout for better spacing on phones

### DIFF
--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -134,9 +134,11 @@
   }
 
   .medal-counts {
-    flex-direction: column;
+    flex-direction: row;
     gap: var(--spacing-sm);
     width: 100%;
+    justify-content: center;
+    flex-wrap: wrap;
   }
 
   .medal-position {
@@ -235,8 +237,10 @@
   }
 
   .competitor-medals {
-    flex-direction: column;
+    flex-direction: row;
     gap: var(--spacing-xs);
+    justify-content: center;
+    flex-wrap: wrap;
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent medal counts and medal badges from stacking vertically on small screens
- center and wrap medal indicators for compact mobile cards

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: Cannot read config file .eslintrc.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a804c3a8d08329b4535daf1fe8714f