### PR TITLE
Improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="sv">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <title>🏆 Pekkas Pokal - Ultimate Competition Tracker</title>
 
     <!-- PWA Meta Tags -->

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -3,7 +3,8 @@
   background: rgba(26, 26, 46, 0.95);
   backdrop-filter: blur(10px);
   border-bottom: 2px solid rgba(102, 126, 234, 0.3);
-  padding: var(--spacing-lg) var(--spacing-xl);
+  padding: calc(var(--spacing-lg) + env(safe-area-inset-top)) var(--spacing-xl)
+    var(--spacing-lg);
   position: sticky;
   top: 0;
   z-index: var(--z-sticky);
@@ -57,10 +58,12 @@
   display: flex;
   gap: var(--spacing-md);
   padding: var(--spacing-md) var(--spacing-xl);
+  padding-bottom: calc(var(--spacing-md) + env(safe-area-inset-bottom));
   background: rgba(26, 26, 46, 0.5);
   border-bottom: 1px solid rgba(102, 126, 234, 0.2);
   overflow-x: auto;
   justify-content: center;
+  scroll-snap-type: x proximity;
 }
 
 .nav-tab {
@@ -75,6 +78,7 @@
   white-space: nowrap;
   position: relative;
   overflow: hidden;
+  scroll-snap-align: center;
 }
 
 .nav-tab::before {


### PR DESCRIPTION
## Summary
- support safe-area insets and scroll-snap navigation for better phone usability
- add `viewport-fit=cover` to viewport meta for full-screen mobile layouts

## Testing
- `npm test` (fails: No test files found)
- `npm run lint` (fails: module is not defined in ES module scope)


------
https://chatgpt.com/codex/tasks/task_e_68a836ee48548329aaec874ca061a4a3