### PR TITLE
feat: Add Host Hero card to dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,6 +200,15 @@
               <span>🏅</span> <span id="wins-count">0 vinster</span>
             </div>
           </div>
+
+          <div class="stat-card">
+            <div class="stat-icon">🏠</div>
+            <div class="stat-value" id="host-hero-name">—</div>
+            <div class="stat-label">Värdmästare</div>
+            <div class="stat-change" id="host-hero-change">
+              <span>🏆</span> <span id="host-hero-count">0 tävlingar</span>
+            </div>
+          </div>
         </div>
 
         <!-- Fun Stats -->

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -529,6 +529,24 @@ class PekkasPokalApp {
       this.updateElement("current-champion", latestComp.winner);
       this.updateElement("champ-comp", `${latestComp.year} ${latestComp.name}`);
     }
+
+    // Host hero
+    if (this.modules.achievementEngine) {
+      const hostCounts = this.modules.achievementEngine.calculateHostCounts(
+        data.participants,
+        data.competitions,
+      );
+      const hostLeader =
+        this.modules.achievementEngine.findLeader(hostCounts);
+
+      if (hostLeader) {
+        this.updateElement("host-hero-name", hostLeader);
+        this.updateElement(
+          "host-hero-count",
+          `${hostCounts[hostLeader]} tävlingar`,
+        );
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
This commit introduces a new card to the dashboard that highlights the 'Host Hero' - the person who has organized the most competitions.

The changes include:
- Adding the HTML structure for the new card in `index.html`.
- Updating the `updateStatsCards` function in `src/scripts/main.js` to calculate and display the Host Hero's name and the number of competitions they have organized.