### PR TITLE
feat: Implement light/dark mode theme switcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,10 @@
         </div>
 
         <div class="header-actions">
-          <!-- Actions can be added here -->
+          <button id="theme-switcher" class="icon-btn" aria-label="Toggle theme">
+            <span class="theme-icon-sun">☀️</span>
+            <span class="theme-icon-moon">🌙</span>
+          </button>
         </div>
       </div>
     </header>

--- a/src/scripts/chart-manager.js
+++ b/src/scripts/chart-manager.js
@@ -7,6 +7,7 @@ class ChartManager {
     this.charts = new Map();
     this.defaultOptions = this.getDefaultOptions();
     this.colorPalette = this.getColorPalette();
+    this.themeConfig = this.getThemeConfig();
     this.initialized = false;
     
     this.init();
@@ -31,6 +32,13 @@ class ChartManager {
     // NOTE: Using the UMD/auto build — components are already registered.
     // Removing the faulty "Chart.register(...Chart.controllers, ...)" call
     // which attempted to spread non-iterable objects and caused a runtime error.
+
+    // Listen for theme changes
+    window.addEventListener('themechange', (e) => this._applyTheme(e.detail.theme));
+
+    // Apply initial theme
+    const initialTheme = document.documentElement.getAttribute('data-theme') || 'dark';
+    this._applyTheme(initialTheme);
     
     this.initialized = true;
     console.log('📊 Chart Manager initialized');
@@ -198,6 +206,9 @@ class ChartManager {
     });
 
     this.charts.set('performance-trend-chart', chart);
+    if (ctx.parentElement) {
+      ctx.parentElement.dataset.chartRendered = 'true';
+    }
   }
 
   /**
@@ -261,6 +272,9 @@ class ChartManager {
     });
 
     this.charts.set('wins-chart', chart);
+    if (ctx.parentElement) {
+      ctx.parentElement.dataset.chartRendered = 'true';
+    }
   }
 
   /**
@@ -359,6 +373,9 @@ class ChartManager {
     });
 
     this.charts.set('medal-distribution-chart', chart);
+    if (ctx.parentElement) {
+      ctx.parentElement.dataset.chartRendered = 'true';
+    }
   }
 
   /**
@@ -448,6 +465,9 @@ class ChartManager {
     });
 
     this.charts.set('avg-position-chart', chart);
+    if (ctx.parentElement) {
+      ctx.parentElement.dataset.chartRendered = 'true';
+    }
   }
 
   /**
@@ -522,6 +542,9 @@ class ChartManager {
     });
 
     this.charts.set('avg-position-chart', chart);
+    if (ctx.parentElement) {
+      ctx.parentElement.dataset.chartRendered = 'true';
+    }
   }
 
   /**
@@ -599,6 +622,9 @@ class ChartManager {
     });
 
     this.charts.set('participation-chart', chart);
+    if (ctx.parentElement) {
+      ctx.parentElement.dataset.chartRendered = 'true';
+    }
   }
 
   /**
@@ -695,6 +721,9 @@ class ChartManager {
     });
 
     this.charts.set('participation-chart', chart);
+    if (ctx.parentElement) {
+      ctx.parentElement.dataset.chartRendered = 'true';
+    }
   }
 
   /**
@@ -786,6 +815,9 @@ class ChartManager {
     });
 
     this.charts.set('placement-trend-chart', chart);
+    if (ctx.parentElement) {
+      ctx.parentElement.dataset.chartRendered = 'true';
+    }
   }
 
   /**
@@ -849,6 +881,9 @@ class ChartManager {
     });
 
     this.charts.set('dashboard-participation-chart', chart);
+    if (ctx.parentElement) {
+      ctx.parentElement.dataset.chartRendered = 'true';
+    }
   }
 
   /**
@@ -947,28 +982,71 @@ class ChartManager {
   }
 
   /**
-   * Update chart theme (for dark/light mode switching)
+   * Get theme-specific color configurations
    */
-  updateTheme(isDark = true) {
-    const textColor = isDark ? '#a8b2d1' : '#374151';
-    const gridColor = isDark ? 'rgba(102, 126, 234, 0.1)' : 'rgba(156, 163, 175, 0.2)';
+  getThemeConfig() {
+    return {
+      dark: {
+        textColor: '#a8b2d1',
+        gridColor: 'rgba(102, 126, 234, 0.1)',
+        tooltipBg: 'rgba(26, 26, 46, 0.95)',
+        tooltipTitle: '#ffffff',
+        tooltipBody: '#a8b2d1',
+      },
+      light: {
+        textColor: '#495057',
+        gridColor: 'rgba(0, 0, 0, 0.1)',
+        tooltipBg: 'rgba(255, 255, 255, 0.95)',
+        tooltipTitle: '#212529',
+        tooltipBody: '#495057',
+      }
+    };
+  }
+
+  /**
+   * Apply theme colors to charts
+   * @private
+   */
+  _applyTheme(theme = 'dark') {
+    const config = this.themeConfig[theme] || this.themeConfig.dark;
+
+    // Update Chart.js global defaults
+    Chart.defaults.color = config.textColor;
     
-    this.charts.forEach((chart, id) => {
-      // Update chart options
+    // Update default options for new charts
+    this.defaultOptions.plugins.legend.labels.color = config.textColor;
+    this.defaultOptions.plugins.tooltip.backgroundColor = config.tooltipBg;
+    this.defaultOptions.plugins.tooltip.titleColor = config.tooltipTitle;
+    this.defaultOptions.plugins.tooltip.bodyColor = config.tooltipBody;
+    this.defaultOptions.scales.x.ticks.color = config.textColor;
+    this.defaultOptions.scales.x.grid.color = config.gridColor;
+    this.defaultOptions.scales.y.ticks.color = config.textColor;
+    this.defaultOptions.scales.y.grid.color = config.gridColor;
+
+    // Update existing charts
+    this.charts.forEach((chart) => {
       if (chart.options.plugins?.legend?.labels) {
-        chart.options.plugins.legend.labels.color = textColor;
+        chart.options.plugins.legend.labels.color = config.textColor;
       }
-      
-      if (chart.options.scales?.x?.ticks) {
-        chart.options.scales.x.ticks.color = textColor;
-        chart.options.scales.x.grid.color = gridColor;
+      if (chart.options.plugins?.tooltip) {
+        chart.options.plugins.tooltip.backgroundColor = config.tooltipBg;
+        chart.options.plugins.tooltip.titleColor = config.tooltipTitle;
+        chart.options.plugins.tooltip.bodyColor = config.tooltipBody;
       }
-      
-      if (chart.options.scales?.y?.ticks) {
-        chart.options.scales.y.ticks.color = textColor;
-        chart.options.scales.y.grid.color = gridColor;
+      if (chart.options.scales?.x) {
+        chart.options.scales.x.ticks.color = config.textColor;
+        chart.options.scales.x.grid.color = config.gridColor;
+        if (chart.options.scales.x.title) {
+          chart.options.scales.x.title.color = config.textColor;
+        }
       }
-      
+      if (chart.options.scales?.y) {
+        chart.options.scales.y.ticks.color = config.textColor;
+        chart.options.scales.y.grid.color = config.gridColor;
+        if (chart.options.scales.y.title) {
+          chart.options.scales.y.title.color = config.textColor;
+        }
+      }
       chart.update('none'); // Update without animation
     });
   }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -38,6 +38,10 @@ class PekkasPokalApp {
       this.setupEventListeners();
       console.log("✅ Event listeners setup");
 
+      // Initialize theme
+      this.initTheme();
+      console.log("✅ Theme initialized");
+
       // Load data
       await this.loadData();
       console.log("✅ Data loaded");
@@ -135,6 +139,40 @@ class PekkasPokalApp {
     this.updateHeaderHeight();
 
     console.log("🎛️ Event listeners setup complete");
+  }
+
+  /**
+   * Initialize theme switcher
+   */
+  initTheme() {
+    this.themeSwitcher = document.getElementById("theme-switcher");
+    if (!this.themeSwitcher) return;
+
+    this.themeSwitcher.addEventListener("click", () => this.toggleTheme());
+
+    const savedTheme = localStorage.getItem("theme") || "dark";
+    this.applyTheme(savedTheme);
+  }
+
+  /**
+   * Apply a theme
+   * @param {string} theme - 'dark' or 'light'
+   */
+  applyTheme(theme) {
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("theme", theme);
+
+    // Dispatch event for other modules to listen to
+    window.dispatchEvent(new CustomEvent("themechange", { detail: { theme } }));
+  }
+
+  /**
+   * Toggle between dark and light themes
+   */
+  toggleTheme() {
+    const currentTheme = document.documentElement.getAttribute("data-theme");
+    const newTheme = currentTheme === "dark" ? "light" : "dark";
+    this.applyTheme(newTheme);
   }
 
   /**

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -962,3 +962,43 @@
   color: #000;
 }
 /* default cell colors can be set inline via JS for other positions */
+
+/* ===== THEME SWITCHER ===== */
+#theme-switcher {
+  font-size: 1.2rem;
+  position: relative;
+  width: 44px;
+  height: 44px;
+  overflow: hidden;
+}
+
+#theme-switcher .theme-icon-sun,
+#theme-switcher .theme-icon-moon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+/* Default state (dark theme) */
+#theme-switcher .theme-icon-sun {
+  opacity: 0;
+  transform: translate(-50%, -50%) rotate(-90deg);
+}
+
+#theme-switcher .theme-icon-moon {
+  opacity: 1;
+  transform: translate(-50%, -50%) rotate(0deg);
+}
+
+/* Light theme state */
+html[data-theme="light"] #theme-switcher .theme-icon-sun {
+  opacity: 1;
+  transform: translate(-50%, -50%) rotate(0deg);
+}
+
+html[data-theme="light"] #theme-switcher .theme-icon-moon {
+  opacity: 0;
+  transform: translate(-50%, -50%) rotate(90deg);
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,5 +1,6 @@
 /* ===== THEME & VARIABLES ===== */
-:root {
+html,
+html[data-theme="dark"] {
   /* Color System */
   --gold: linear-gradient(135deg, #FFD700, #FFA500);
   --silver: linear-gradient(135deg, #C0C0C0, #808080);
@@ -24,6 +25,15 @@
   --success: #4ade80;
   --danger: #f87171;
   --warning: #fbbf24;
+
+  /* Component-specific variables */
+  --body-bg-image: radial-gradient(circle at 20% 80%, rgba(102, 126, 234, 0.1) 0%, transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(118, 75, 162, 0.1) 0%, transparent 50%);
+  --form-control-bg: rgba(255, 255, 255, 0.05);
+  --form-control-border: rgba(102, 126, 234, 0.3);
+  --btn-secondary-bg: rgba(255, 255, 255, 0.1);
+  --btn-secondary-bg-hover: rgba(255, 255, 255, 0.2);
+  --btn-secondary-border: rgba(255, 255, 255, 0.2);
   
   /* Spacing */
   --spacing-xs: 0.25rem;
@@ -71,6 +81,47 @@
   --z-toast: 1080;
 }
 
+html[data-theme="light"] {
+  /* Light Theme Color System */
+  --gold: linear-gradient(135deg, #FFD700, #FFA500);
+  --silver: linear-gradient(135deg, #C0C0C0, #808080);
+  --bronze: linear-gradient(135deg, #CD7F32, #8B4513);
+
+  --epic-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  --legendary-gradient: linear-gradient(135deg, #FFD700 0%, #FF6B6B 100%);
+  --mythic-gradient: linear-gradient(135deg, #FF00FF 0%, #00FFFF 100%);
+  --fire-gradient: linear-gradient(135deg, #ff6b6b 0%, #feca57 100%);
+  --ice-gradient: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+  --nature-gradient: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
+
+  /* Base Colors */
+  --bg-dark: #f0f2f5;
+  --bg-card: #ffffff;
+  --bg-card-hover: #f8f9fa;
+  --text-primary: #212529;
+  --text-secondary: #495057;
+  --text-muted: #6c757d;
+  --accent: #5a67d8;
+  --success: #28a745;
+  --danger: #dc3545;
+  --warning: #ffc107;
+
+  /* Component-specific variables */
+  --body-bg-image: radial-gradient(circle at 20% 80%, rgba(102, 126, 234, 0.05) 0%, transparent 40%),
+    radial-gradient(circle at 80% 20%, rgba(118, 75, 162, 0.05) 0%, transparent 40%);
+  --form-control-bg: #ffffff;
+  --form-control-border: #ced4da;
+  --btn-secondary-bg: #e9ecef;
+  --btn-secondary-bg-hover: #d3d9df;
+  --btn-secondary-border: #ced4da;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
+  --shadow-xl: 0 20px 25px rgba(0, 0, 0, 0.1);
+}
+
 /* ===== RESET & BASE STYLES ===== */
 * {
   margin: 0;
@@ -89,9 +140,7 @@ body {
   color: var(--text-primary);
   min-height: 100vh;
   line-height: 1.6;
-  background-image: 
-    radial-gradient(circle at 20% 80%, rgba(102, 126, 234, 0.1) 0%, transparent 50%),
-    radial-gradient(circle at 80% 20%, rgba(118, 75, 162, 0.1) 0%, transparent 50%);
+  background-image: var(--body-bg-image);
   background-attachment: fixed;
 }
 
@@ -183,13 +232,13 @@ p {
 }
 
 .btn-secondary {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--btn-secondary-bg);
   color: var(--text-primary);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--btn-secondary-border);
 }
 
 .btn-secondary:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.2);
+  background: var(--btn-secondary-bg-hover);
 }
 
 .icon-btn {
@@ -216,8 +265,8 @@ p {
 .form-control {
   width: 100%;
   padding: var(--spacing-sm) var(--spacing-md);
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(102, 126, 234, 0.3);
+  background: var(--form-control-bg);
+  border: 1px solid var(--form-control-border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
   font-size: var(--text-sm);


### PR DESCRIPTION
This commit introduces a new feature: a light/dark mode theme switcher.

Key changes:
- Adds a theme toggle button to the header with sun/moon icons.
- Implements the core theme-switching logic in `main.js`, including saving the user's preference to localStorage.
- Defines a full set of CSS variables for both light and dark themes in `main.css`, ensuring a consistent look and feel.
- Makes the Chart.js charts theme-aware by updating their colors when the theme is changed. The `ChartManager` now listens for a `themechange` event.
- Adds a `data-chart-rendered` attribute to chart containers to improve testability.