### PR TITLE
feat: Add average ranking chart and multi-year filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,7 +354,7 @@
         <!-- Enhanced Filters -->
         <div class="stats-controls">
           <div class="competitor-multiselect" id="competitor-filter"></div>
-          <select id="timeframe-filter" class="filter-select">
+          <select id="timeframe-filter" class="filter-select" multiple>
             <option value="all">Alla År</option>
             <option value="recent5">Senaste 5 År</option>
             <option value="recent3">Senaste 3 År</option>
@@ -400,6 +400,13 @@
             </div>
             <canvas id="participation-chart"></canvas>
           </div>
+        </div>
+
+        <div class="chart-container">
+          <div class="chart-header">
+            <div class="chart-title">📊 Genomsnittlig ranking</div>
+          </div>
+          <canvas id="average-ranking-chart"></canvas>
         </div>
 
         <div class="chart-container">

--- a/src/scripts/chart-manager.js
+++ b/src/scripts/chart-manager.js
@@ -886,13 +886,69 @@ class ChartManager {
     }
   }
 
+  createAverageRankingChart(averageRankings) {
+    const ctx = document.getElementById('average-ranking-chart');
+    if (!ctx) {
+      console.warn('Average ranking chart canvas not found');
+      return;
+    }
+
+    this.destroyChart('average-ranking-chart');
+
+    const sortedRankings = Object.entries(averageRankings)
+      .sort((a, b) => a[1] - b[1]);
+
+    const options = {
+      ...this.defaultOptions,
+      plugins: {
+        ...this.defaultOptions.plugins,
+        legend: { display: false }
+      },
+      scales: {
+        ...this.defaultOptions.scales,
+        y: {
+          ...this.defaultOptions.scales.y,
+          beginAtZero: false,
+          title: { display: true, text: 'Genomsnittlig ranking', color: '#a8b2d1' }
+        },
+        x: {
+          ...this.defaultOptions.scales.x,
+          title: { display: true, text: 'Deltagare', color: '#a8b2d1' }
+        }
+      }
+    };
+
+    const chart = new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: sortedRankings.map(([name]) => name),
+        datasets: [
+          {
+            label: 'Genomsnittlig ranking',
+            data: sortedRankings.map(([, ranking]) => ranking),
+            backgroundColor: this.colorPalette.primary,
+            borderColor: this.colorPalette.primary,
+            borderWidth: 1
+          }
+        ]
+      },
+      options: options
+    });
+
+    this.charts.set('average-ranking-chart', chart);
+    if (ctx.parentElement) {
+      ctx.parentElement.dataset.chartRendered = 'true';
+    }
+  }
+
   /**
    * Update statistics charts
    */
-  updateStatisticsCharts(filteredData) {
+  updateStatisticsCharts(filteredData, averageRankings) {
     this.createAveragePositionChart(filteredData);
     this.createParticipationChart(filteredData);
     this.createPlacementTrendChart(filteredData);
+    this.createAverageRankingChart(averageRankings);
   }
 
   /**

--- a/src/scripts/filters.js
+++ b/src/scripts/filters.js
@@ -55,31 +55,41 @@ class FilterManager {
    * Apply timeframe filter
    */
   applyTimeframeFilter(competitions, timeframe) {
-    if (timeframe === 'all') return competitions;
-    
-    const currentYear = new Date().getFullYear();
-    let startYear;
-    
-    switch (timeframe) {
-      case 'recent5':
-        startYear = currentYear - 4;
-        break;
-      case 'recent3':
-        startYear = currentYear - 2;
-        break;
-      case 'recent1':
-        startYear = currentYear;
-        break;
-      default:
-        // Assume it's a specific year
-        const year = parseInt(timeframe);
-        if (!isNaN(year)) {
-          return competitions.filter(c => c.year === year);
-        }
-        return competitions;
+    if (timeframe === 'all' || !timeframe || (Array.isArray(timeframe) && timeframe.includes('all'))) {
+      return competitions;
+    }
+
+    if (!Array.isArray(timeframe)) {
+      timeframe = [timeframe];
     }
     
-    return competitions.filter(c => c.year >= startYear);
+    const yearsToFilter = new Set();
+    const currentYear = new Date().getFullYear();
+
+    timeframe.forEach(value => {
+      switch (value) {
+        case 'recent5':
+          for (let i = 0; i < 5; i++) yearsToFilter.add(currentYear - i);
+          break;
+        case 'recent3':
+          for (let i = 0; i < 3; i++) yearsToFilter.add(currentYear - i);
+          break;
+        case 'recent1':
+          yearsToFilter.add(currentYear);
+          break;
+        default:
+          const year = parseInt(value);
+          if (!isNaN(year)) {
+            yearsToFilter.add(year);
+          }
+      }
+    });
+
+    if (yearsToFilter.size === 0) {
+      return competitions;
+    }
+    
+    return competitions.filter(c => yearsToFilter.has(c.year));
   }
 
   /**

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -249,7 +249,11 @@ class PekkasPokalApp {
           const filterType = e.target.id
             .replace("-filter", "")
             .replace(/-([a-z])/g, (_, c) => c.toUpperCase());
-          this.state.filters[filterType] = e.target.value;
+          if (e.target.multiple) {
+            this.state.filters[filterType] = Array.from(e.target.selectedOptions).map(o => o.value);
+          } else {
+            this.state.filters[filterType] = e.target.value;
+          }
           this.applyFilters();
         });
       }
@@ -774,12 +778,14 @@ class PekkasPokalApp {
         this.state.competitionData,
         this.state.filters,
       );
+      const averageRankings = this.modules.statistics.calculateAverageRankings(filteredData);
       // FilterManager returns an object containing competitions, participants and the
       // original data. The statistics components only need the competitions array,
       // so pass that to avoid runtime errors when iterating over the result.
       this.modules.uiComponents.updateStatisticsView(filteredData.competitions);
       this.modules.chartManager.updateStatisticsCharts(
         filteredData.competitions,
+        averageRankings,
       );
     }
   }

--- a/src/scripts/statistics.js
+++ b/src/scripts/statistics.js
@@ -304,6 +304,25 @@ class Statistics {
     return counts;
   }
 
+  calculateAverageRankings(data) {
+    const averageRankings = {};
+
+    data.participants.forEach(p => {
+      const positions = [];
+      data.competitions.forEach(comp => {
+        if (comp.scores[p.id]) {
+          positions.push(comp.scores[p.id]);
+        }
+      });
+
+      if (positions.length > 0) {
+        averageRankings[p.name] = this.calculateMean(positions);
+      }
+    });
+
+    return averageRankings;
+  }
+
   /**
    * Calculate head-to-head records between participants
    */


### PR DESCRIPTION
This commit introduces two new features:

1.  A new bar chart in the statistics tab that displays the average ranking for each participant based on the filtered competitions.
2.  The ability to select multiple years in the year filter on the statistics tab.

The changes include:
- Modifying `index.html` to add a canvas for the new chart and to make the year filter a multi-select.
- Updating `src/scripts/filters.js` to handle multiple selected years.
- Adding a new function to `src/scripts/statistics.js` to calculate the average rankings.
- Adding a new function to `src/scripts/chart-manager.js` to create the average ranking chart.
- Integrating the new chart and multi-year filter functionality in `src/scripts/main.js`.