### PR TITLE
feat: Implement multi-year filter for statistics

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,16 +354,7 @@
         <!-- Enhanced Filters -->
         <div class="stats-controls">
           <div class="competitor-multiselect" id="competitor-filter"></div>
-          <select id="timeframe-filter" class="filter-select" multiple>
-            <option value="all">Alla År</option>
-            <option value="recent5">Senaste 5 År</option>
-            <option value="recent3">Senaste 3 År</option>
-            <option value="2025">2025</option>
-            <option value="2024">2024</option>
-            <option value="2023">2023</option>
-            <option value="2022">2022</option>
-            <option value="2021">2021</option>
-          </select>
+          <div class="year-multiselect" id="timeframe-filter"></div>
           <select id="competition-type-filter" class="filter-select">
             <option value="all">Alla Tävlingar</option>
           </select>
@@ -528,6 +519,7 @@
     <script src="src/scripts/statistics.js"></script>
     <script src="src/scripts/filters.js"></script>
     <script src="src/scripts/components/competitor-filter.js"></script>
+    <script src="src/scripts/components/year-filter.js"></script>
     <script src="src/scripts/main.js"></script>
 
     <!-- Initialize app when all scripts are loaded -->

--- a/src/scripts/components/year-filter.js
+++ b/src/scripts/components/year-filter.js
@@ -1,0 +1,128 @@
+class YearMultiSelect {
+  constructor(container, { onChange } = {}) {
+    this.container = container;
+    this.onChange = onChange;
+    this.options = [];
+    this.selected = new Map();
+    this.build();
+  }
+
+  build() {
+    this.container.classList.add("year-multiselect");
+
+    this.chipContainer = document.createElement("div");
+    this.chipContainer.className = "chip-container";
+
+    this.input = document.createElement("input");
+    this.input.type = "text";
+    this.input.className = "year-search";
+    this.input.placeholder = "Sök år...";
+
+    this.dropdown = document.createElement("div");
+    this.dropdown.className = "year-options";
+
+    this.container.appendChild(this.chipContainer);
+    this.container.appendChild(this.input);
+    this.container.appendChild(this.dropdown);
+
+    this.input.addEventListener("input", () => this.renderOptions());
+    this.input.addEventListener("focus", () => this.renderOptions());
+
+    document.addEventListener("click", (e) => {
+      if (!this.container.contains(e.target)) {
+        this.dropdown.style.display = "none";
+      }
+    });
+
+    this.renderChips();
+  }
+
+  setOptions(options = []) {
+    this.options = options;
+    this.renderOptions();
+  }
+
+  renderOptions() {
+    const query = this.input.value.toLowerCase();
+    this.dropdown.innerHTML = "";
+    const filtered = this.options.filter(
+      (o) => !this.selected.has(o.id) && String(o.name).toLowerCase().includes(query),
+    );
+
+    if (filtered.length === 0) {
+      this.dropdown.style.display = "none";
+      return;
+    }
+
+    filtered.forEach((o) => {
+      const opt = document.createElement("div");
+      opt.className = "year-option";
+      opt.textContent = o.name;
+      opt.dataset.id = o.id;
+      opt.addEventListener("click", () => {
+        this.selected.set(o.id, o.name);
+        this.input.value = "";
+        this.renderChips();
+        this.renderOptions();
+        this.triggerChange();
+      });
+      this.dropdown.appendChild(opt);
+    });
+
+    this.dropdown.style.display = "block";
+  }
+
+  renderChips() {
+    this.chipContainer.innerHTML = "";
+    if (this.selected.size === 0) {
+      const placeholder = document.createElement("span");
+      placeholder.className = "placeholder";
+      placeholder.textContent = "Alla År";
+      this.chipContainer.appendChild(placeholder);
+      return;
+    }
+
+    this.selected.forEach((name, id) => {
+      const chip = document.createElement("span");
+      chip.className = "year-chip";
+      chip.textContent = name;
+
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "remove-chip";
+      btn.textContent = "×";
+      btn.addEventListener("click", () => {
+        this.selected.delete(id);
+        this.renderChips();
+        this.renderOptions();
+        this.triggerChange();
+      });
+
+      chip.appendChild(btn);
+      this.chipContainer.appendChild(chip);
+    });
+  }
+
+  getSelected() {
+    return Array.from(this.selected.keys());
+  }
+
+  setSelected(ids = [], silent = false) {
+    this.selected.clear();
+    ids.forEach((id) => {
+      const opt = this.options.find((o) => o.id === id);
+      if (opt) this.selected.set(opt.id, opt.name);
+    });
+    this.renderChips();
+    this.renderOptions();
+    if (!silent) this.triggerChange();
+  }
+
+  triggerChange() {
+    if (typeof this.onChange === "function") {
+      this.onChange(this.getSelected());
+    }
+  }
+}
+
+window.YearMultiSelect = YearMultiSelect;

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -213,7 +213,7 @@ class PekkasPokalApp {
     const achievementContainer = document.getElementById(
       "achievement-competitor-filter",
     );
-    const timeframeFilter = document.getElementById("timeframe-filter");
+    const timeframeContainer = document.getElementById("timeframe-filter");
     const competitionTypeFilter = document.getElementById(
       "competition-type-filter",
     );
@@ -243,21 +243,21 @@ class PekkasPokalApp {
       );
     }
 
-    [timeframeFilter, competitionTypeFilter].forEach((filter) => {
-      if (filter) {
-        filter.addEventListener("change", (e) => {
-          const filterType = e.target.id
-            .replace("-filter", "")
-            .replace(/-([a-z])/g, (_, c) => c.toUpperCase());
-          if (e.target.multiple) {
-            this.state.filters[filterType] = Array.from(e.target.selectedOptions).map(o => o.value);
-          } else {
-            this.state.filters[filterType] = e.target.value;
-          }
+    if (typeof YearMultiSelect !== "undefined") {
+      this.yearSelect = new YearMultiSelect(timeframeContainer, {
+        onChange: (values) => {
+          this.state.filters.timeframe = values.length ? values.map(Number) : "all";
           this.applyFilters();
-        });
-      }
-    });
+        },
+      });
+    }
+
+    if (competitionTypeFilter) {
+      competitionTypeFilter.addEventListener("change", (e) => {
+        this.state.filters.competitionType = e.target.value;
+        this.applyFilters();
+      });
+    }
 
     if (resetBtn) {
       resetBtn.addEventListener("click", () => {
@@ -441,6 +441,16 @@ class PekkasPokalApp {
     if (this.achievementCompetitorSelect) {
       this.achievementCompetitorSelect.setOptions(participants);
       this.achievementCompetitorSelect.setSelected(selected, true);
+    }
+
+    // Timeframe filter
+    if (this.yearSelect) {
+      const years = [...new Set(this.state.competitionData.competitions.map(c => c.year))]
+        .sort((a, b) => b - a)
+        .map(year => ({ id: year, name: String(year) }));
+      this.yearSelect.setOptions(years);
+      const selectedYears = this.state.filters.timeframe === 'all' ? [] : this.state.filters.timeframe;
+      this.yearSelect.setSelected(selectedYears, true);
     }
 
     // Competition type filter
@@ -815,7 +825,7 @@ class PekkasPokalApp {
     if (this.competitorSelect) this.competitorSelect.setSelected([], true);
     if (this.achievementCompetitorSelect)
       this.achievementCompetitorSelect.setSelected([], true);
-    this.updateElement("timeframe-filter", "all", "value");
+    if (this.yearSelect) this.yearSelect.setSelected([], true);
     this.updateElement("competition-type-filter", "all", "value");
 
     this.applyFilters();


### PR DESCRIPTION
Replaces the standard HTML select element for the year filter with a custom multi-select component, `YearMultiSelect`. This new component allows users to select multiple years, search for specific years, and view selections as chips, mirroring the functionality of the existing competitor filter.

- Creates a new `YearMultiSelect` class in `src/scripts/components/year-filter.js`.
- Updates `index.html` to use a `div` for the new component and includes the new script.
- Modifies `src/scripts/main.js` to initialize, populate, and handle state changes for the new year filter.