### PR TITLE
feat: Replace competition type filter with multi-select component

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,9 +355,7 @@
         <div class="stats-controls">
           <div class="competitor-multiselect" id="competitor-filter"></div>
           <div class="year-multiselect" id="timeframe-filter"></div>
-          <select id="competition-type-filter" class="filter-select">
-            <option value="all">Alla Tävlingar</option>
-          </select>
+          <div id="competition-type-filter"></div>
           <button
             id="reset-filters-btn"
             class="icon-btn"
@@ -520,6 +518,7 @@
     <script src="src/scripts/filters.js"></script>
     <script src="src/scripts/components/competitor-filter.js"></script>
     <script src="src/scripts/components/year-filter.js"></script>
+    <script src="src/scripts/components/competition-type-filter.js"></script>
     <script src="src/scripts/main.js"></script>
 
     <!-- Initialize app when all scripts are loaded -->

--- a/src/scripts/components/competition-type-filter.js
+++ b/src/scripts/components/competition-type-filter.js
@@ -1,0 +1,128 @@
+class CompetitionTypeMultiSelect {
+  constructor(container, { onChange } = {}) {
+    this.container = container;
+    this.onChange = onChange;
+    this.options = [];
+    this.selected = new Map();
+    this.build();
+  }
+
+  build() {
+    this.container.classList.add("competitor-multiselect");
+
+    this.chipContainer = document.createElement("div");
+    this.chipContainer.className = "chip-container";
+
+    this.input = document.createElement("input");
+    this.input.type = "text";
+    this.input.className = "competitor-search";
+    this.input.placeholder = "Sök tävlingstyp...";
+
+    this.dropdown = document.createElement("div");
+    this.dropdown.className = "competitor-options";
+
+    this.container.appendChild(this.chipContainer);
+    this.container.appendChild(this.input);
+    this.container.appendChild(this.dropdown);
+
+    this.input.addEventListener("input", () => this.renderOptions());
+    this.input.addEventListener("focus", () => this.renderOptions());
+
+    document.addEventListener("click", (e) => {
+      if (!this.container.contains(e.target)) {
+        this.dropdown.style.display = "none";
+      }
+    });
+
+    this.renderChips();
+  }
+
+  setOptions(options = []) {
+    this.options = options;
+    this.renderOptions();
+  }
+
+  renderOptions() {
+    const query = this.input.value.toLowerCase();
+    this.dropdown.innerHTML = "";
+    const filtered = this.options.filter(
+      (o) => !this.selected.has(o.id) && String(o.name).toLowerCase().includes(query),
+    );
+
+    if (filtered.length === 0) {
+      this.dropdown.style.display = "none";
+      return;
+    }
+
+    filtered.forEach((o) => {
+      const opt = document.createElement("div");
+      opt.className = "competitor-option";
+      opt.textContent = o.name;
+      opt.dataset.id = o.id;
+      opt.addEventListener("click", () => {
+        this.selected.set(o.id, o.name);
+        this.input.value = "";
+        this.renderChips();
+        this.renderOptions();
+        this.triggerChange();
+      });
+      this.dropdown.appendChild(opt);
+    });
+
+    this.dropdown.style.display = "block";
+  }
+
+  renderChips() {
+    this.chipContainer.innerHTML = "";
+    if (this.selected.size === 0) {
+      const placeholder = document.createElement("span");
+      placeholder.className = "placeholder";
+      placeholder.textContent = "Alla Tävlingstyper";
+      this.chipContainer.appendChild(placeholder);
+      return;
+    }
+
+    this.selected.forEach((name, id) => {
+      const chip = document.createElement("span");
+      chip.className = "competitor-chip";
+      chip.textContent = name;
+
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "remove-chip";
+      btn.textContent = "×";
+      btn.addEventListener("click", () => {
+        this.selected.delete(id);
+        this.renderChips();
+        this.renderOptions();
+        this.triggerChange();
+      });
+
+      chip.appendChild(btn);
+      this.chipContainer.appendChild(chip);
+    });
+  }
+
+  getSelected() {
+    return Array.from(this.selected.keys());
+  }
+
+  setSelected(ids = [], silent = false) {
+    this.selected.clear();
+    ids.forEach((id) => {
+      const opt = this.options.find((o) => o.id === id);
+      if (opt) this.selected.set(opt.id, opt.name);
+    });
+    this.renderChips();
+    this.renderOptions();
+    if (!silent) this.triggerChange();
+  }
+
+  triggerChange() {
+    if (typeof this.onChange === "function") {
+      this.onChange(this.getSelected());
+    }
+  }
+}
+
+window.CompetitionTypeMultiSelect = CompetitionTypeMultiSelect;

--- a/src/scripts/filters.js
+++ b/src/scripts/filters.js
@@ -96,9 +96,17 @@ class FilterManager {
    * Apply competition type filter
    */
   applyCompetitionTypeFilter(competitions, competitionType) {
-    if (competitionType === 'all') return competitions;
+    if (competitionType === 'all' || (Array.isArray(competitionType) && competitionType.length === 0)) {
+      return competitions;
+    }
+
+    const typesToFilter = new Set(Array.isArray(competitionType) ? competitionType : [competitionType]);
     
-    return competitions.filter(c => c.name === competitionType);
+    if (typesToFilter.has('all')) {
+        return competitions;
+    }
+
+    return competitions.filter(c => typesToFilter.has(c.name));
   }
 
   /**

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -214,7 +214,7 @@ class PekkasPokalApp {
       "achievement-competitor-filter",
     );
     const timeframeContainer = document.getElementById("timeframe-filter");
-    const competitionTypeFilter = document.getElementById(
+    const competitionTypeContainer = document.getElementById(
       "competition-type-filter",
     );
     const resetBtn = document.getElementById("reset-filters-btn");
@@ -252,10 +252,12 @@ class PekkasPokalApp {
       });
     }
 
-    if (competitionTypeFilter) {
-      competitionTypeFilter.addEventListener("change", (e) => {
-        this.state.filters.competitionType = e.target.value;
-        this.applyFilters();
+    if (typeof CompetitionTypeMultiSelect !== "undefined") {
+      this.competitionTypeSelect = new CompetitionTypeMultiSelect(competitionTypeContainer, {
+        onChange: (values) => {
+          this.state.filters.competitionType = values.length ? values : "all";
+          this.applyFilters();
+        },
       });
     }
 
@@ -454,18 +456,12 @@ class PekkasPokalApp {
     }
 
     // Competition type filter
-    const competitionTypes = [
-      ...new Set(this.state.competitionData.competitions.map((c) => c.name)),
-    ];
-    const typeFilter = document.getElementById("competition-type-filter");
-    if (typeFilter) {
-      typeFilter.innerHTML = '<option value="all">Alla Tävlingar</option>';
-      competitionTypes.forEach((type) => {
-        const option = document.createElement("option");
-        option.value = type;
-        option.textContent = type;
-        typeFilter.appendChild(option);
-      });
+    if (this.competitionTypeSelect) {
+      const competitionTypes = [...new Set(this.state.competitionData.competitions.map((c) => c.name))]
+        .map(type => ({ id: type, name: type }));
+      this.competitionTypeSelect.setOptions(competitionTypes);
+      const selectedTypes = this.state.filters.competitionType === 'all' ? [] : this.state.filters.competitionType;
+      this.competitionTypeSelect.setSelected(selectedTypes, true);
     }
   }
 
@@ -826,7 +822,7 @@ class PekkasPokalApp {
     if (this.achievementCompetitorSelect)
       this.achievementCompetitorSelect.setSelected([], true);
     if (this.yearSelect) this.yearSelect.setSelected([], true);
-    this.updateElement("competition-type-filter", "all", "value");
+    if (this.competitionTypeSelect) this.competitionTypeSelect.setSelected([], true);
 
     this.applyFilters();
   }


### PR DESCRIPTION
This commit replaces the old single-selection dropdown for the competition type filter with a new multi-select component that allows for selecting multiple competition types.

The new component, `CompetitionTypeMultiSelect`, is implemented in a new file, `src/scripts/components/competition-type-filter.js`, and is designed to match the look, feel, and functionality of the existing year and competitor filters.

The filtering logic in `filters.js` has been updated to handle an array of competition types, and `main.js` has been modified to initialize and manage the new component.

This change provides users with more powerful and flexible filtering capabilities on the statistics page.