### PR TITLE
feat: Align heatmap colors with user preference

### DIFF
--- a/src/scripts/ui-components.js
+++ b/src/scripts/ui-components.js
@@ -326,12 +326,10 @@ class UIComponents {
         if (position) {
           cell.textContent = position;
           cell.dataset.position = position;
-          if (Number(position) > 3) {
-            cell.style.background = this.getHeatmapColor(
-              Number(position),
-              maxPosition,
-            );
-          }
+          cell.style.background = this.getHeatmapColor(
+            Number(position),
+            maxPosition,
+          );
         } else {
           cell.textContent = "-";
         }
@@ -352,28 +350,28 @@ class UIComponents {
   getHeatmapColor(position, maxPosition) {
     if (!maxPosition || position < 1) return "";
 
-    // Normalize position to a 0-1 range.
+    // Normalize position to a 0-1 range
     const ratio = (position - 1) / (maxPosition - 1 || 1);
 
-    // Define colors for the gradient (good, neutral, bad).
-    const goodColor = { r: 59, g: 130, b: 246 }; // Blue 500
-    const neutralColor = { r: 248, g: 250, b: 252 }; // Gray 50
-    const badColor = { r: 239, g: 68, b: 68 }; // Red 500
+    // Define colors for the gradient (good, mid, bad)
+    const goodColor = { r: 76, g: 175, b: 80 }; // Material Green
+    const midColor = { r: 255, g: 235, b: 59 }; // Material Yellow
+    const badColor = { r: 244, g: 67, b: 54 }; // Material Red
 
     let r, g, b;
 
     if (ratio < 0.5) {
-      // Interpolate between good (blue) and neutral (white).
+      // Interpolate between good and mid
       const localRatio = ratio * 2;
-      r = Math.round(goodColor.r + (neutralColor.r - goodColor.r) * localRatio);
-      g = Math.round(goodColor.g + (neutralColor.g - goodColor.g) * localRatio);
-      b = Math.round(goodColor.b + (neutralColor.b - goodColor.b) * localRatio);
+      r = Math.round(goodColor.r + (midColor.r - goodColor.r) * localRatio);
+      g = Math.round(goodColor.g + (midColor.g - goodColor.g) * localRatio);
+      b = Math.round(goodColor.b + (midColor.b - goodColor.b) * localRatio);
     } else {
-      // Interpolate between neutral (white) and bad (red).
+      // Interpolate between mid and bad
       const localRatio = (ratio - 0.5) * 2;
-      r = Math.round(neutralColor.r + (badColor.r - neutralColor.r) * localRatio);
-      g = Math.round(neutralColor.g + (badColor.g - neutralColor.g) * localRatio);
-      b = Math.round(neutralColor.b + (badColor.b - neutralColor.b) * localRatio);
+      r = Math.round(midColor.r + (badColor.r - midColor.r) * localRatio);
+      g = Math.round(midColor.g + (badColor.g - midColor.g) * localRatio);
+      b = Math.round(midColor.b + (badColor.b - midColor.b) * localRatio);
     }
 
     return `rgb(${r}, ${g}, ${b})`;


### PR DESCRIPTION
This change reverts the heatmap color scheme to the original green-yellow-red gradient, as requested by the user. It also ensures that the 1st, 2nd, and 3rd place positions in the heatmap are colored according to this gradient, rather than being uncolored.

This provides a consistent color scheme across the entire heatmap, aligning with the user's feedback.