### PR TITLE
fix: add trophy icon for start screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       content="Årlig tävling för vänner med omfattande statistik och datahantering"
     />
     <link rel="manifest" href="manifest.json" />
+    <link rel="icon" href="icon-192.svg" type="image/svg+xml" />
 
     <!-- Stylesheets -->
     <link rel="stylesheet" href="src/styles/main.css" />

--- a/public/icon-192.svg
+++ b/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 192 192'>
+  <rect width='192' height='192' fill='#667eea' rx='20'/>
+  <text x='96' y='140' text-anchor='middle' font-size='120' fill='white'>🏆</text>
+</svg>

--- a/public/icon-512.svg
+++ b/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'>
+  <rect width='512' height='512' fill='#667eea' rx='50'/>
+  <text x='256' y='360' text-anchor='middle' font-size='300' fill='white'>🏆</text>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -12,13 +12,13 @@
   "lang": "sv-SE",
   "icons": [
     {
-      "src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 192 192'><rect width='192' height='192' fill='%23667eea' rx='20'/><text x='96' y='140' text-anchor='middle' font-size='120' fill='white'>🏆</text></svg>",
+      "src": "icon-192.svg",
       "sizes": "192x192",
       "type": "image/svg+xml",
       "purpose": "any maskable"
     },
     {
-      "src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><rect width='512' height='512' fill='%23667eea' rx='50'/><text x='256' y='360' text-anchor='middle' font-size='300' fill='white'>🏆</text></svg>",
+      "src": "icon-512.svg",
       "sizes": "512x512",
       "type": "image/svg+xml",
       "purpose": "any maskable"


### PR DESCRIPTION
## Summary
- add SVG trophy icons for PWA start screen
- link favicon in main HTML document

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: Cannot read config file /.eslintrc.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6d4fc4e8832980f46730b78f682d