### PR TITLE
Add Spel tab with a Three.js pinball table for 2025

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,7 @@ jobs:
           cp -r src/styles dist/src/
           cp -r src/scripts dist/src/
           cp -r src/data dist/src/
+          cp -r src/games dist/src/
           
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/README.md
+++ b/README.md
@@ -74,6 +74,32 @@ Bilden dyker upp automatiskt högst upp på det årets kort i Historik och i
 resultatrutan. Saknas en bild händer ingenting — inget att konfigurera.
 Liggande format och ca 1200 px bredd fungerar bäst.
 
+### 4. Spel
+
+Fliken **Spel** innehåller ett spel per år. 2025 är *Pekkas Pokal Flipper* — ett
+flipperspel i Three.js som byggs helt i webbläsaren (ingen bild- eller
+ljudfil laddas ner, bara Three.js självt, och först när man öppnar spelet).
+
+Att lägga till ett nytt års spel:
+
+1. Skapa modulen under `src/games/<spel>/index.js` och exportera en funktion
+   `createX(container, opts)` som returnerar `{ destroy() }`.
+2. Lägg till en rad i `GAMES` i [`src/scripts/app.js`](src/scripts/app.js) med
+   `year`, `title`, `tagline`, `icon` och sökvägen i `module`.
+
+År utan spel visas automatiskt som "inte byggt än".
+
+**Kontroller i flipperspelet**
+
+| | Mobil | Dator |
+| --- | --- | --- |
+| Flippers | Vänster/höger halva av skärmen (fungerar samtidigt) | ←/→, A/D eller Z/M |
+| Avfyrare | Håll för kraft, släpp för att skjuta | Mellanslag |
+| Nudga | Knappen NUDGA | N |
+
+Släpp avfyraren när mätaren står i det turkosa fältet för en **skill shot**.
+Fyra nudgar för snabbt ger TILT och dödar flipprarna för den bollen.
+
 ---
 
 ## Utveckling
@@ -93,7 +119,8 @@ npm run lint     # ESLint
 | `src/scripts/app.js` | Hela applikationen: dataladdning, statistik, Elo, rendering |
 | `src/scripts/achievement-engine.js` | Beräknar vilka utmärkelser varje deltagare låst upp |
 | `src/data/achievements.js` | Definitioner av alla utmärkelser |
-| `src/styles/` | `main` (tokens/teman), `layout`, `components`, `animations`, `responsive` |
+| `src/styles/` | `main` (tokens/teman), `layout`, `components`, `animations`, `games`, `responsive` |
+| `src/games/pinball/` | Flipperspelet: `physics` (2D-kollision), `table` (layout + banans grafik), `meshes` (3D), `index` (spelloop) |
 | `public/` | Statiska filer: `event.json`, `manifest.json`, ikoner, `og-image.png`, `photos/` |
 
 Data hämtas från `competition-data.csv` vid sidladdning. Om filen inte går att

--- a/index.html
+++ b/index.html
@@ -42,11 +42,22 @@
       crossorigin=""
     />
 
+    <!-- Three.js, resolved when the pinball table is opened -->
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://unpkg.com/three@0.170.0/build/three.module.js",
+          "three/addons/": "https://unpkg.com/three@0.170.0/examples/jsm/"
+        }
+      }
+    </script>
+
     <!-- Styles -->
     <link rel="stylesheet" href="src/styles/main.css" />
     <link rel="stylesheet" href="src/styles/layout.css" />
     <link rel="stylesheet" href="src/styles/components.css" />
     <link rel="stylesheet" href="src/styles/animations.css" />
+    <link rel="stylesheet" href="src/styles/games.css" />
     <link rel="stylesheet" href="src/styles/responsive.css" />
 
     <script>
@@ -106,6 +117,7 @@
           <button class="nav-link" data-view="history">Historik</button>
           <button class="nav-link" data-view="achievements">Utmärkelser</button>
           <button class="nav-link" data-view="stats">Statistik</button>
+          <button class="nav-link" data-view="games">Spel</button>
           <span class="nav-indicator" aria-hidden="true"></span>
         </nav>
 
@@ -345,7 +357,27 @@
           <div class="elo-standings" id="elo-standings"></div>
         </div>
       </section>
+      <!-- ============ SPEL ============ -->
+      <section id="view-games" class="view" aria-label="Spel">
+        <div class="view-head">
+          <h1>Spel</h1>
+          <p class="view-sub">Ett spel per år — spela årets gren när som helst.</p>
+        </div>
+        <div class="game-grid" id="game-grid"></div>
+      </section>
     </main>
+
+    <!-- Full-screen game stage -->
+    <div class="game-stage" id="game-stage" hidden>
+      <button class="game-close" id="game-close" aria-label="Stäng spelet">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+      </button>
+      <div class="game-mount" id="game-mount"></div>
+      <div class="game-loading" id="game-loading">
+        <div class="game-spinner"></div>
+        <p id="game-loading-text">Bygger bordet…</p>
+      </div>
+    </div>
 
     <footer class="site-footer">
       <p>Pekkas Pokal · sedan 2011 · <span id="footer-count">—</span> tävlingar och räknar uppåt</p>
@@ -372,6 +404,10 @@
       <button class="tab-item" data-view="stats" aria-label="Statistik">
         <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 20V10M10 20V4M16 20v-7M22 20H2"/></svg>
         <span>Statistik</span>
+      </button>
+      <button class="tab-item" data-view="games" aria-label="Spel">
+        <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 11h4M8 9v4M15 11h.01M18 13h.01"/><path d="M17.32 6H6.68a4.68 4.68 0 0 0-4.65 4.13l-.87 7A2.5 2.5 0 0 0 3.64 20c1.1 0 2.08-.72 2.4-1.78L6.6 16h10.8l.56 2.22A2.5 2.5 0 0 0 20.36 20a2.5 2.5 0 0 0 2.48-2.87l-.87-7A4.68 4.68 0 0 0 17.32 6Z"/></svg>
+        <span>Spel</span>
       </button>
     </nav>
 

--- a/src/games/pinball/index.js
+++ b/src/games/pinball/index.js
@@ -1,0 +1,839 @@
+/**
+ * Pekkas Pokal Flipper — a Three.js pinball table.
+ *
+ * Loaded on demand from the Spel tab. Everything (physics, art, audio) is
+ * generated at runtime, so the only download is Three.js itself.
+ */
+
+import * as THREE from 'three';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+
+import { World, Ball, clamp } from './physics.js';
+import { L, buildColliders, createPlayfieldCanvas } from './table.js';
+import { buildTable, createMaterials } from './meshes.js';
+
+const BALLS_PER_GAME = 3;
+const BALL_SAVE_MS = 9000;
+const HIGHSCORE_KEY = 'pp-flipper-highscore';
+// Release the plunger inside this band of the meter for a skill shot
+const SKILL_ZONE = [0.68, 0.86];
+
+/* --------------------------------------------------------------------- audio */
+
+class Sfx {
+  constructor() {
+    this.ctx = null;
+    this.muted = false;
+  }
+
+  resume() {
+    if (!this.ctx) {
+      const AC = window.AudioContext || window.webkitAudioContext;
+      if (!AC) return;
+      this.ctx = new AC();
+      this.master = this.ctx.createGain();
+      this.master.gain.value = 0.32;
+      this.master.connect(this.ctx.destination);
+    }
+    if (this.ctx.state === 'suspended') this.ctx.resume();
+  }
+
+  tone(freq, dur, type = 'triangle', gain = 1, sweep = 0) {
+    if (!this.ctx || this.muted) return;
+    const t = this.ctx.currentTime;
+    const osc = this.ctx.createOscillator();
+    const env = this.ctx.createGain();
+    osc.type = type;
+    osc.frequency.setValueAtTime(freq, t);
+    if (sweep) osc.frequency.exponentialRampToValueAtTime(Math.max(40, freq + sweep), t + dur);
+    env.gain.setValueAtTime(0.0001, t);
+    env.gain.exponentialRampToValueAtTime(gain, t + 0.006);
+    env.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+    osc.connect(env).connect(this.master);
+    osc.start(t);
+    osc.stop(t + dur + 0.02);
+  }
+
+  noise(dur, gain = 0.5, freq = 900) {
+    if (!this.ctx || this.muted) return;
+    const t = this.ctx.currentTime;
+    const n = Math.floor(this.ctx.sampleRate * dur);
+    const buf = this.ctx.createBuffer(1, n, this.ctx.sampleRate);
+    const data = buf.getChannelData(0);
+    for (let i = 0; i < n; i++) data[i] = (Math.random() * 2 - 1) * (1 - i / n);
+    const src = this.ctx.createBufferSource();
+    src.buffer = buf;
+    const filt = this.ctx.createBiquadFilter();
+    filt.type = 'bandpass';
+    filt.frequency.value = freq;
+    const env = this.ctx.createGain();
+    env.gain.value = gain;
+    src.connect(filt).connect(env).connect(this.master);
+    src.start(t);
+  }
+
+  bumper() { this.tone(520, 0.13, 'square', 0.5, 340); }
+  sling() { this.tone(300, 0.09, 'sawtooth', 0.35, 180); }
+  flipper() { this.noise(0.05, 0.32, 2400); }
+  target() { this.tone(760, 0.1, 'square', 0.4, 240); }
+  wall() { this.noise(0.035, 0.12, 1500); }
+  jackpot() {
+    [0, 90, 180, 300].forEach((d, i) => setTimeout(() => this.tone(523 * (1 + i * 0.26), 0.18, 'triangle', 0.5), d));
+  }
+  launch() { this.tone(180, 0.22, 'sawtooth', 0.4, 420); }
+  drain() { this.tone(220, 0.5, 'sine', 0.4, -150); }
+  complete() {
+    [0, 70, 140, 210, 320].forEach((d, i) => setTimeout(() => this.tone(392 * 2 ** (i / 6), 0.2, 'square', 0.4), d));
+  }
+}
+
+/* ---------------------------------------------------------------------- HUD */
+
+function buildHud(root) {
+  root.innerHTML = `
+    <div class="pb-hud">
+      <div class="pb-top">
+        <div class="pb-score-wrap">
+          <div class="pb-score" id="pb-score">0</div>
+          <div class="pb-hi">REKORD <span id="pb-hi">0</span></div>
+        </div>
+        <div class="pb-meta">
+          <div class="pb-mult" id="pb-mult">×1</div>
+          <div class="pb-balls" id="pb-balls"></div>
+        </div>
+      </div>
+      <div class="pb-pokal" id="pb-pokal"></div>
+      <div class="pb-toast" id="pb-toast"></div>
+    </div>
+
+    <div class="pb-overlay" id="pb-overlay">
+      <div class="pb-panel">
+        <h2 id="pb-title">Pekkas Pokal Flipper</h2>
+        <p id="pb-text">Tryck och håll för att spänna avfyraren. Vänster och höger sida av skärmen styr varsin flipper.</p>
+        <div class="pb-scoreline" id="pb-scoreline" hidden></div>
+        <button class="pb-btn" id="pb-start">Starta spelet</button>
+      </div>
+    </div>
+
+    <div class="pb-controls" id="pb-controls" hidden>
+      <button class="pb-nudge" id="pb-nudge" aria-label="Nudga bordet">NUDGA</button>
+    </div>
+
+    <div class="pb-plunger" id="pb-plunger" hidden>
+      <div class="pb-plunger-label">Håll för kraft — släpp för att skjuta</div>
+      <div class="pb-power"><i class="pb-skill"></i><span id="pb-power-fill"></span></div>
+    </div>
+
+    <button class="pb-mute" id="pb-mute" aria-label="Ljud på/av">
+      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M11 5 6 9H2v6h4l5 4V5Z"/><path class="pb-wave" d="M15.5 8.5a5 5 0 0 1 0 7"/>
+      </svg>
+    </button>
+  `;
+  return {
+    score: root.querySelector('#pb-score'),
+    hi: root.querySelector('#pb-hi'),
+    mult: root.querySelector('#pb-mult'),
+    balls: root.querySelector('#pb-balls'),
+    pokal: root.querySelector('#pb-pokal'),
+    toast: root.querySelector('#pb-toast'),
+    overlay: root.querySelector('#pb-overlay'),
+    title: root.querySelector('#pb-title'),
+    text: root.querySelector('#pb-text'),
+    scoreline: root.querySelector('#pb-scoreline'),
+    start: root.querySelector('#pb-start'),
+    controls: root.querySelector('#pb-controls'),
+    nudge: root.querySelector('#pb-nudge'),
+    plunger: root.querySelector('#pb-plunger'),
+    powerFill: root.querySelector('#pb-power-fill'),
+    mute: root.querySelector('#pb-mute')
+  };
+}
+
+/* -------------------------------------------------------------------- game */
+
+export async function createPinball(container, opts = {}) {
+  const participants = opts.participants || [];
+  const canvasHost = document.createElement('div');
+  canvasHost.className = 'pb-canvas';
+  container.appendChild(canvasHost);
+
+  const hudHost = document.createElement('div');
+  hudHost.className = 'pb-ui';
+  container.appendChild(hudHost);
+  const hud = buildHud(hudHost);
+
+  const sfx = new Sfx();
+
+  /* ---- Renderer ---- */
+  const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
+  const maxDpr = window.innerWidth < 700 ? 2 : 1.8;
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, maxDpr));
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 0.86;
+  canvasHost.appendChild(renderer.domElement);
+
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x05070f);
+  scene.fog = new THREE.Fog(0x05070f, 52, 96);
+
+  const camera = new THREE.PerspectiveCamera(42, 1, 0.5, 220);
+
+  /* ---- Environment reflections ---- */
+  const pmrem = new THREE.PMREMGenerator(renderer);
+  const envRT = pmrem.fromScene(new RoomEnvironment(), 0.06);
+  scene.environment = envRT.texture;
+  // RoomEnvironment is a bright studio; at full strength it washes the table out
+  scene.environmentIntensity = 0.3;
+
+  /* ---- Table ---- */
+  if (document.fonts && document.fonts.ready) {
+    try {
+      await document.fonts.ready;
+    } catch (e) {
+      /* fonts are cosmetic */
+    }
+  }
+  const { canvas: pfCanvas } = createPlayfieldCanvas(participants);
+  const pfTexture = new THREE.CanvasTexture(pfCanvas);
+  pfTexture.colorSpace = THREE.SRGBColorSpace;
+  pfTexture.anisotropy = Math.min(8, renderer.capabilities.getMaxAnisotropy());
+
+  const materials = createMaterials(THREE, pfTexture);
+  const { group: tableGroup, refs } = buildTable(THREE, mergeGeometries, materials);
+  scene.add(tableGroup);
+
+  /* ---- Lights ---- */
+  scene.add(new THREE.AmbientLight(0x9fb0ff, 0.16));
+
+  const key = new THREE.DirectionalLight(0xfff3e0, 1.1);
+  key.position.set(9, 30, -6);
+  key.target.position.set(0, 0, -20);
+  key.castShadow = true;
+  key.shadow.mapSize.set(1024, 1024);
+  key.shadow.camera.near = 6;
+  key.shadow.camera.far = 70;
+  key.shadow.camera.left = -16;
+  key.shadow.camera.right = 16;
+  key.shadow.camera.top = 30;
+  key.shadow.camera.bottom = -30;
+  key.shadow.bias = -0.0016;
+  scene.add(key, key.target);
+
+  const rim = new THREE.DirectionalLight(0x7c8cf8, 0.5);
+  rim.position.set(-12, 12, -46);
+  scene.add(rim);
+
+  const warm = new THREE.PointLight(0xf2c14e, 0.8, 30, 2);
+  warm.position.set(L.centerX, 9, -10);
+  scene.add(warm);
+
+  /* ---- Post-processing ---- */
+  const composer = new EffectComposer(renderer);
+  composer.addPass(new RenderPass(scene, camera));
+  const bloom = new UnrealBloomPass(new THREE.Vector2(256, 256), 0.5, 0.6, 0.88);
+  composer.addPass(bloom);
+  composer.addPass(new OutputPass());
+
+  /* ---- Physics ---- */
+  const world = new World({ gravity: 27, damping: 0.2, maxSpeed: 64 });
+  const ball = new Ball(L.ballRadius);
+
+  const state = {
+    phase: 'idle', // idle | launch | play | between | over
+    score: 0,
+    ballNo: 1,
+    mult: 1,
+    pokal: [false, false, false, false, false],
+    banksDone: 0,
+    ballSaveUntil: 0,
+    stuckFor: 0,
+    laneFor: 0,
+    nudges: [],
+    tilted: false,
+    power: 0,
+    charging: false,
+    lastToast: 0
+  };
+
+  let high = 0;
+  try {
+    high = parseInt(localStorage.getItem(HIGHSCORE_KEY) || '0', 10) || 0;
+  } catch (e) {
+    high = 0;
+  }
+  hud.hi.textContent = high.toLocaleString('sv-SE');
+
+  /* ---- HUD helpers ---- */
+  const fmt = (n) => n.toLocaleString('sv-SE');
+
+  function renderBalls() {
+    hud.balls.innerHTML = Array.from({ length: BALLS_PER_GAME }, (_, i) =>
+      `<span class="pb-ball-dot ${i < BALLS_PER_GAME - state.ballNo + 1 ? 'on' : ''}"></span>`
+    ).join('');
+  }
+
+  function renderPokal() {
+    hud.pokal.innerHTML = L.targets
+      .map((t, i) => `<span class="pb-letter ${state.pokal[i] ? 'lit' : ''}">${t.letter}</span>`)
+      .join('');
+  }
+
+  function addScore(n) {
+    state.score += Math.round(n * state.mult);
+    hud.score.textContent = fmt(state.score);
+  }
+
+  function toast(msg, big = false) {
+    hud.toast.textContent = msg;
+    hud.toast.className = `pb-toast show${big ? ' big' : ''}`;
+    clearTimeout(state.lastToast);
+    state.lastToast = setTimeout(() => {
+      hud.toast.className = 'pb-toast';
+    }, big ? 1800 : 1100);
+  }
+
+  /* ---- Effects ---- */
+  const flashes = [];
+  function flash(obj, light, strength = 3) {
+    if (light) {
+      light.intensity = strength;
+      flashes.push({ light, t: 0 });
+    }
+    if (obj) obj.scale.multiplyScalar(1.13);
+  }
+
+  /* ---- Gameplay hooks ---- */
+  // Declared up front: the hooks below close over it, but they only fire once
+  // buildColliders has returned.
+  let colliderRefs = null;
+
+  const hooks = {
+    onBumper(i, v) {
+      if (v < 1) return;
+      addScore(120);
+      sfx.bumper();
+      const b = refs.bumpers[i];
+      flash(b.trophy, b.light, 4.2);
+    },
+    onSling(side, v) {
+      if (v < 1) return;
+      addScore(60);
+      sfx.sling();
+      const mesh = side === 'left' ? refs.leftSling : refs.rightSling;
+      if (mesh) {
+        mesh.material.emissiveIntensity = 4;
+        flashes.push({ mat: mesh.material, base: 1.4, t: 0 });
+      }
+    },
+    onTarget(i, v) {
+      if (v < 0.6 || state.pokal[i]) return;
+      state.pokal[i] = true;
+      colliderRefs.targets[i].enabled = false;
+      refs.targets[i].down = true;
+      addScore(600);
+      sfx.target();
+      renderPokal();
+
+      if (state.pokal.every(Boolean)) {
+        state.banksDone++;
+        state.mult = Math.min(6, state.mult + 1);
+        hud.mult.textContent = `×${state.mult}`;
+        addScore(6000);
+        sfx.complete();
+        toast(`P-O-K-A-L KOMPLETT — ×${state.mult}`, true);
+        setTimeout(resetBank, 1700);
+      } else {
+        toast(`${L.targets[i].letter} träffad`);
+      }
+    },
+    onJackpot(v) {
+      if (v < 1) return;
+      const lit = state.banksDone > 0;
+      addScore(lit ? 25000 : 2500);
+      sfx.jackpot();
+      flash(refs.jackpot.trophy, refs.jackpot.light, 6);
+      toast(lit ? 'JACKPOT!' : 'Pokalen träffad', lit);
+    },
+    onWall(v) {
+      if (v > 9) sfx.wall();
+    },
+    onFlipper(side, v) {
+      if (v > 3) sfx.flipper();
+    }
+  };
+
+  colliderRefs = buildColliders(world, hooks);
+
+  function resetBank() {
+    state.pokal = [false, false, false, false, false];
+    colliderRefs.targets.forEach((c) => {
+      c.enabled = true;
+    });
+    refs.targets.forEach((t) => {
+      t.down = false;
+    });
+    renderPokal();
+  }
+
+  /* ---- Ball lifecycle ---- */
+  function placeInLane() {
+    ball.place(L.laneBallX, L.laneBottomY + L.laneWallR + L.ballRadius + 0.06, 0, 0);
+    ball.live = true;
+    state.phase = 'launch';
+    state.power = 0;
+    state.charging = false;
+    hud.plunger.hidden = false;
+    hud.controls.hidden = true;
+    hud.powerFill.style.width = '0%';
+  }
+
+  function launchBall() {
+    // Looping the habitrail costs ~48 u/s of climb, so every launch clears it.
+    // The meter is a timing skill shot instead of a power that can strand you.
+    const p = clamp(state.power, 0, 1);
+    ball.vy = 51 + p * 11;
+    ball.vx = 0;
+    state.phase = 'play';
+    state.ballSaveUntil = performance.now() + BALL_SAVE_MS;
+    hud.plunger.hidden = true;
+    hud.controls.hidden = false;
+    sfx.launch();
+
+    if (p >= SKILL_ZONE[0] && p <= SKILL_ZONE[1]) {
+      addScore(5000);
+      sfx.complete();
+      toast('SKILL SHOT +5000', true);
+    } else {
+      toast('Bollen är i spel');
+    }
+  }
+
+  function drainBall() {
+    if (state.phase !== 'play') return;
+
+    if (performance.now() < state.ballSaveUntil) {
+      sfx.launch();
+      toast('BOLLRÄDDNING', true);
+      placeInLane();
+      state.power = 0.72;
+      setTimeout(() => {
+        if (state.phase === 'launch') launchBall();
+      }, 550);
+      return;
+    }
+
+    sfx.drain();
+    ball.live = false;
+    state.phase = 'between';
+
+    if (state.ballNo >= BALLS_PER_GAME) {
+      setTimeout(gameOver, 900);
+      return;
+    }
+    state.ballNo++;
+    state.mult = 1;
+    hud.mult.textContent = '×1';
+    renderBalls();
+    toast(`Boll ${state.ballNo} av ${BALLS_PER_GAME}`, true);
+    setTimeout(() => {
+      if (state.phase === 'between') placeInLane();
+    }, 1100);
+  }
+
+  function gameOver() {
+    state.phase = 'over';
+    hud.controls.hidden = true;
+    hud.plunger.hidden = true;
+    const isHigh = state.score > high;
+    if (isHigh) {
+      high = state.score;
+      try {
+        localStorage.setItem(HIGHSCORE_KEY, String(high));
+      } catch (e) {
+        /* private mode */
+      }
+      hud.hi.textContent = fmt(high);
+    }
+    hud.title.textContent = isHigh ? 'Nytt rekord!' : 'Spelet slut';
+    hud.text.textContent = isHigh
+      ? 'Bäst hittills på den här enheten. Snyggt spelat.'
+      : 'Bollarna är slut. En gång till?';
+    hud.scoreline.hidden = false;
+    hud.scoreline.innerHTML = `<span>${fmt(state.score)}</span><small>poäng · rekord ${fmt(high)}</small>`;
+    hud.start.textContent = 'Spela igen';
+    hud.overlay.classList.add('show');
+  }
+
+  function startGame() {
+    sfx.resume();
+    state.score = 0;
+    state.ballNo = 1;
+    state.mult = 1;
+    state.banksDone = 0;
+    state.tilted = false;
+    state.nudges = [];
+    hud.score.textContent = '0';
+    hud.mult.textContent = '×1';
+    hud.scoreline.hidden = true;
+    hud.overlay.classList.remove('show');
+    resetBank();
+    renderBalls();
+    placeInLane();
+  }
+
+  /* ---- Input ---- */
+  const pointers = new Map();
+  const flipL = colliderRefs.flippers.left;
+  const flipR = colliderRefs.flippers.right;
+
+  function setFlipper(side, pressed) {
+    if (state.tilted) return;
+    const f = side === 'left' ? flipL : flipR;
+    if (f.pressed !== pressed) {
+      f.pressed = pressed;
+      if (pressed) sfx.flipper();
+    }
+  }
+
+  function refreshFlippers() {
+    let left = false;
+    let right = false;
+    pointers.forEach((side) => {
+      if (side === 'left') left = true;
+      else if (side === 'right') right = true;
+    });
+    setFlipper('left', left);
+    setFlipper('right', right);
+  }
+
+  function onPointerDown(e) {
+    sfx.resume();
+    if (e.target.closest('.pb-overlay, .pb-mute, .pb-nudge')) return;
+    canvasHost.setPointerCapture?.(e.pointerId);
+
+    if (state.phase === 'launch') {
+      state.charging = true;
+      pointers.set(e.pointerId, 'plunger');
+      return;
+    }
+    if (state.phase !== 'play') return;
+
+    const rect = canvasHost.getBoundingClientRect();
+    const side = e.clientX - rect.left < rect.width / 2 ? 'left' : 'right';
+    pointers.set(e.pointerId, side);
+    refreshFlippers();
+  }
+
+  function onPointerUp(e) {
+    const was = pointers.get(e.pointerId);
+    pointers.delete(e.pointerId);
+    if (was === 'plunger' && state.phase === 'launch') {
+      state.charging = false;
+      launchBall();
+      return;
+    }
+    refreshFlippers();
+  }
+
+  function onPointerMove(e) {
+    if (state.phase !== 'play' || !pointers.has(e.pointerId)) return;
+    // Let a finger slide across the middle to swap flippers
+    const rect = canvasHost.getBoundingClientRect();
+    const side = e.clientX - rect.left < rect.width / 2 ? 'left' : 'right';
+    if (pointers.get(e.pointerId) !== side) {
+      pointers.set(e.pointerId, side);
+      refreshFlippers();
+    }
+  }
+
+  function onKeyDown(e) {
+    if (e.repeat) return;
+    const k = e.key.toLowerCase();
+    if (k === 'arrowleft' || k === 'a' || k === 'z') setFlipper('left', true);
+    else if (k === 'arrowright' || k === 'd' || k === 'm') setFlipper('right', true);
+    else if (k === ' ') {
+      e.preventDefault();
+      sfx.resume();
+      if (state.phase === 'launch') state.charging = true;
+      else if (state.phase === 'idle' || state.phase === 'over') startGame();
+    } else if (k === 'n') doNudge();
+  }
+
+  function onKeyUp(e) {
+    const k = e.key.toLowerCase();
+    if (k === 'arrowleft' || k === 'a' || k === 'z') setFlipper('left', false);
+    else if (k === 'arrowright' || k === 'd' || k === 'm') setFlipper('right', false);
+    else if (k === ' ' && state.phase === 'launch' && state.charging) {
+      state.charging = false;
+      launchBall();
+    }
+  }
+
+  function doNudge() {
+    if (state.phase !== 'play' || state.tilted) return;
+    const now = performance.now();
+    state.nudges = state.nudges.filter((t) => now - t < 3200);
+    state.nudges.push(now);
+
+    if (state.nudges.length > 3) {
+      state.tilted = true;
+      flipL.pressed = false;
+      flipR.pressed = false;
+      toast('TILT — flipprarna är döda', true);
+      sfx.drain();
+      return;
+    }
+    world.nudgeX = (Math.random() - 0.5) * 70;
+    world.nudgeY = 34;
+    ball.vx += (Math.random() - 0.5) * 5;
+    ball.vy += 2.6;
+    setTimeout(() => {
+      world.nudgeX = 0;
+      world.nudgeY = 0;
+    }, 90);
+    sfx.wall();
+    toast('Nudge');
+  }
+
+  canvasHost.addEventListener('pointerdown', onPointerDown);
+  window.addEventListener('pointerup', onPointerUp);
+  window.addEventListener('pointercancel', onPointerUp);
+  canvasHost.addEventListener('pointermove', onPointerMove);
+  window.addEventListener('keydown', onKeyDown);
+  window.addEventListener('keyup', onKeyUp);
+  hud.start.addEventListener('click', startGame);
+  hud.nudge.addEventListener('click', doNudge);
+  hud.mute.addEventListener('click', () => {
+    sfx.muted = !sfx.muted;
+    hud.mute.classList.toggle('off', sfx.muted);
+  });
+
+  /* ---- Camera fit ---- */
+  const target = new THREE.Vector3(0, 0, -19);
+  const pitch = 67 * (Math.PI / 180);
+  const dir = new THREE.Vector3(0, Math.sin(pitch), Math.cos(pitch));
+  const corners = [];
+  for (const x of [-L.outerX - 0.35, L.outerX + 0.35]) {
+    for (const z of [0.5, -41.5]) {
+      corners.push(new THREE.Vector3(x, 0, z));
+      corners.push(new THREE.Vector3(x, 2, z));
+    }
+  }
+
+  function fitCamera() {
+    const rect = canvasHost.getBoundingClientRect();
+    const w = Math.max(1, rect.width);
+    const h = Math.max(1, rect.height);
+    camera.aspect = w / h;
+    // Wider lens on narrow screens so the table still fills the view
+    camera.fov = camera.aspect < 0.62 ? 50 : 42;
+
+    let dist = 52;
+    for (let iter = 0; iter < 6; iter++) {
+      camera.position.copy(target).addScaledVector(dir, dist);
+      camera.lookAt(target);
+      camera.updateProjectionMatrix();
+      camera.updateMatrixWorld();
+
+      let maxRatio = 0;
+      corners.forEach((c) => {
+        const p = c.clone().project(camera);
+        maxRatio = Math.max(maxRatio, Math.abs(p.x) / 0.995, Math.abs(p.y) / 0.995);
+      });
+      if (maxRatio < 1.001 && maxRatio > 0.985) break;
+      dist *= maxRatio > 0 ? maxRatio : 1;
+      dist = clamp(dist, 20, 160);
+    }
+    camera.position.copy(target).addScaledVector(dir, dist);
+    camera.lookAt(target);
+    camera.updateProjectionMatrix();
+  }
+
+  function resize() {
+    const rect = canvasHost.getBoundingClientRect();
+    const w = Math.max(1, Math.floor(rect.width));
+    const h = Math.max(1, Math.floor(rect.height));
+    renderer.setSize(w, h, false);
+    composer.setSize(w, h);
+    bloom.setSize(Math.min(320, w / 2), Math.min(560, h / 2));
+    fitCamera();
+  }
+
+  const ro = new ResizeObserver(resize);
+  ro.observe(canvasHost);
+  resize();
+
+  /* ---- Loop ---- */
+  let raf = 0;
+  let last = performance.now();
+  let acc = 0;
+  const FIXED = 1 / 120;
+  let running = true;
+
+  function tick(now) {
+    raf = requestAnimationFrame(tick);
+    const dtRaw = Math.min(0.05, (now - last) / 1000);
+    last = now;
+    if (!running) return;
+
+    // Plunger charge
+    if (state.phase === 'launch' && state.charging) {
+      state.power = Math.min(1, state.power + dtRaw * 1.15);
+      hud.powerFill.style.width = `${state.power * 100}%`;
+    }
+
+    acc += dtRaw;
+    let guard = 0;
+    while (acc >= FIXED && guard++ < 8) {
+      world.step(ball, FIXED);
+      acc -= FIXED;
+
+      if (state.phase === 'play' && ball.live) {
+        if (ball.y < -1.2 || ball.y > 48 || Math.abs(ball.x) > 13) drainBall();
+
+        // A ball loitering in the shooter lane can never get out on its own
+        if (ball.x > L.laneX && ball.y < L.domeY && ball.speed < 4) {
+          state.laneFor += FIXED;
+          if (state.laneFor > 1.4) {
+            ball.vy = 52;
+            ball.vx = 0;
+            state.laneFor = 0;
+            sfx.launch();
+          }
+        } else {
+          state.laneFor = 0;
+        }
+
+        // Rescue a ball wedged somewhere with no energy
+        if (ball.speed < 0.9) {
+          state.stuckFor += FIXED;
+          if (state.stuckFor > 3.4) {
+            ball.vx += (Math.random() - 0.5) * 10;
+            ball.vy += 7;
+            state.stuckFor = 0;
+          }
+        } else {
+          state.stuckFor = 0;
+        }
+      }
+    }
+
+    // Ball transform + rolling spin
+    refs.ball.position.set(ball.x, L.ballRadius + 0.04, -ball.y);
+    if (ball.speed > 0.01) {
+      const axis = new THREE.Vector3(-ball.vy, 0, -ball.vx).normalize();
+      refs.ball.rotateOnWorldAxis(axis, (ball.speed * dtRaw) / L.ballRadius);
+    }
+    refs.ball.visible = ball.live;
+
+    // Flippers
+    refs.flippers.left.rotation.y = -flipL.angle;
+    refs.flippers.right.rotation.y = -flipR.angle;
+
+    // Plunger pull-back
+    if (refs.plunger) {
+      const back = state.phase === 'launch' ? state.power * 1.5 : 0;
+      refs.plunger.position.z = -L.laneBottomY + 0.6 + back;
+    }
+
+    // Drop target animation
+    refs.targets.forEach((t, i) => {
+      const want = t.down ? -1.05 : 0;
+      t.group.position.y += (want - t.group.position.y) * Math.min(1, dtRaw * 14);
+      t.face.material.emissiveIntensity = t.down ? 0 : 0.9;
+      t.face.material.color.set(state.pokal[i] ? 0x3a4265 : 0xf26d8d);
+    });
+
+    // Idle shimmer + flash decay
+    const t = now / 1000;
+    refs.jackpot.trophy.rotation.y = t * 0.9;
+    refs.jackpot.halo.scale.setScalar(1 + Math.sin(t * 2.4) * 0.06);
+    refs.bumpers.forEach((b, i) => {
+      b.trophy.rotation.y = t * 1.4 + i;
+      b.group.scale.lerp(new THREE.Vector3(1, 1, 1), Math.min(1, dtRaw * 9));
+    });
+
+    for (let i = flashes.length - 1; i >= 0; i--) {
+      const f = flashes[i];
+      f.t += dtRaw;
+      if (f.light) {
+        f.light.intensity = Math.max(0, f.light.intensity - dtRaw * 14);
+        if (f.light.intensity <= 0.01) flashes.splice(i, 1);
+      } else if (f.mat) {
+        f.mat.emissiveIntensity = Math.max(f.base, f.mat.emissiveIntensity - dtRaw * 16);
+        if (f.mat.emissiveIntensity <= f.base + 0.01) flashes.splice(i, 1);
+      }
+    }
+
+    // Gentle parallax toward the action
+    target.x += (ball.x * 0.1 - target.x) * Math.min(1, dtRaw * 2);
+    camera.lookAt(target);
+
+    composer.render();
+  }
+
+  raf = requestAnimationFrame(tick);
+
+  const onVisibility = () => {
+    running = !document.hidden;
+    last = performance.now();
+    if (document.hidden) {
+      flipL.pressed = false;
+      flipR.pressed = false;
+      pointers.clear();
+    }
+  };
+  document.addEventListener('visibilitychange', onVisibility);
+
+  renderBalls();
+  renderPokal();
+  hud.overlay.classList.add('show');
+
+  /* ---- Teardown ---- */
+  function destroy() {
+    cancelAnimationFrame(raf);
+    running = false;
+    ro.disconnect();
+    document.removeEventListener('visibilitychange', onVisibility);
+    canvasHost.removeEventListener('pointerdown', onPointerDown);
+    canvasHost.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', onPointerUp);
+    window.removeEventListener('pointercancel', onPointerUp);
+    window.removeEventListener('keydown', onKeyDown);
+    window.removeEventListener('keyup', onKeyUp);
+    clearTimeout(state.lastToast);
+
+    scene.traverse((o) => {
+      if (o.geometry) o.geometry.dispose();
+      if (o.material) {
+        const mats = Array.isArray(o.material) ? o.material : [o.material];
+        mats.forEach((m) => {
+          Object.values(m).forEach((v) => {
+            if (v && v.isTexture) v.dispose();
+          });
+          m.dispose();
+        });
+      }
+    });
+    pfTexture.dispose();
+    envRT.texture.dispose();
+    pmrem.dispose();
+    composer.dispose?.();
+    renderer.dispose();
+    renderer.forceContextLoss?.();
+    if (sfx.ctx) sfx.ctx.close();
+    container.innerHTML = '';
+  }
+
+  return { destroy };
+}
+
+export default createPinball;

--- a/src/games/pinball/meshes.js
+++ b/src/games/pinball/meshes.js
@@ -1,0 +1,352 @@
+/**
+ * Builds the 3D table from the same layout the physics uses.
+ *
+ * Playfield (x, y) maps to world (x, height, -y): the table lies in the XZ
+ * plane with +Y up, so a 2D shape drawn in playfield coordinates can be
+ * extruded upward and dropped straight in.
+ */
+
+import { L, mirrorX } from './table.js';
+
+/** Extruding a shape drawn in playfield space lands it flat, height along +Y. */
+function flatten(geo) {
+  geo.rotateX(-Math.PI / 2);
+  return geo;
+}
+
+/**
+ * Capsule outline between two points — the silhouette of every wall and rail.
+ */
+function capsuleShape(THREE, ax, ay, bx, by, r) {
+  const shape = new THREE.Shape();
+  const ang = Math.atan2(by - ay, bx - ax);
+  shape.absarc(ax, ay, r, ang + Math.PI / 2, ang - Math.PI / 2, true);
+  shape.absarc(bx, by, r, ang - Math.PI / 2, ang + Math.PI / 2, true);
+  shape.closePath();
+  return shape;
+}
+
+/**
+ * Flipper silhouette: two circles of different radii joined by their outer
+ * tangents, pivot at the origin pointing along +x.
+ */
+function flipperShape(THREE, length, r0, r1) {
+  const alpha = Math.asin((r0 - r1) / length);
+  const shape = new THREE.Shape();
+  shape.absarc(0, 0, r0, Math.PI / 2 + alpha, -Math.PI / 2 - alpha, true);
+  shape.absarc(length, 0, r1, -Math.PI / 2 - alpha, Math.PI / 2 + alpha, true);
+  shape.closePath();
+  return shape;
+}
+
+/** The Pekkas Pokal trophy, turned on a lathe. */
+export function trophyGeometry(THREE) {
+  const profile = [
+    [0, 0], [0.54, 0], [0.54, 0.08], [0.24, 0.14], [0.18, 0.38],
+    [0.44, 0.46], [0.58, 0.86], [0.52, 0.9], [0.2, 0.66], [0, 0.62]
+  ].map((p) => new THREE.Vector2(p[0], p[1]));
+  return new THREE.LatheGeometry(profile, 40);
+}
+
+/* -------------------------------------------------------------- materials */
+
+export function createMaterials(THREE, playfieldTexture) {
+  return {
+    playfield: new THREE.MeshStandardMaterial({
+      map: playfieldTexture,
+      roughness: 0.5,
+      metalness: 0.1,
+      envMapIntensity: 0.3
+    }),
+    chrome: new THREE.MeshStandardMaterial({
+      color: 0xdfe6ff,
+      roughness: 0.16,
+      metalness: 1,
+      envMapIntensity: 1
+    }),
+    rail: new THREE.MeshStandardMaterial({
+      color: 0x7c88a8,
+      roughness: 0.3,
+      metalness: 0.9,
+      envMapIntensity: 0.5
+    }),
+    gold: new THREE.MeshStandardMaterial({
+      color: 0xf2c14e,
+      roughness: 0.26,
+      metalness: 1,
+      envMapIntensity: 0.55,
+      emissive: 0x2a1e04,
+      emissiveIntensity: 1
+    }),
+    goldGlow: new THREE.MeshStandardMaterial({
+      color: 0xf2c14e,
+      roughness: 0.34,
+      metalness: 0.55,
+      envMapIntensity: 0.4,
+      emissive: 0xf2c14e,
+      emissiveIntensity: 0.95
+    }),
+    blueGlow: new THREE.MeshStandardMaterial({
+      color: 0x7c8cf8,
+      roughness: 0.34,
+      metalness: 0.45,
+      envMapIntensity: 0.4,
+      emissive: 0x7c8cf8,
+      emissiveIntensity: 0.8
+    }),
+    rubber: new THREE.MeshStandardMaterial({
+      color: 0x10152a,
+      roughness: 0.8,
+      metalness: 0.1,
+      envMapIntensity: 0.25
+    }),
+    targetUp: new THREE.MeshStandardMaterial({
+      color: 0xf26d8d,
+      roughness: 0.4,
+      metalness: 0.35,
+      envMapIntensity: 0.35,
+      emissive: 0xf26d8d,
+      emissiveIntensity: 0.6
+    }),
+    targetDown: new THREE.MeshStandardMaterial({
+      color: 0x3a4265,
+      roughness: 0.6,
+      metalness: 0.3,
+      emissive: 0x000000
+    })
+  };
+}
+
+/* ------------------------------------------------------------------ builder */
+
+export function buildTable(THREE, mergeGeometries, materials) {
+  const group = new THREE.Group();
+  const refs = { bumpers: [], targets: [], flippers: {}, lights: [] };
+
+  /* ---- Playfield ---- */
+  const artW = L.outerX * 2 + 1.2;
+  const artH = 44;
+  // No extra spin: the plane's +y becomes world -z, which is up-table, so the
+  // canvas lands the right way up with the title at the top of the playfield.
+  const playfield = new THREE.Mesh(
+    flatten(new THREE.PlaneGeometry(artW, artH, 1, 1)),
+    materials.playfield
+  );
+  // PlaneGeometry is centred; ART spans y -2..42 → centre 20
+  playfield.position.set(0, 0, -20);
+  playfield.receiveShadow = true;
+  group.add(playfield);
+
+  /* ---- Walls ---- */
+  const wallShapes = [];
+  const pushChain = (pts, r = 0.3) => {
+    for (let i = 0; i < pts.length - 1; i++) {
+      wallShapes.push(capsuleShape(THREE, pts[i][0], pts[i][1], pts[i + 1][0], pts[i + 1][1], r));
+    }
+  };
+  const pushArc = (cx, cy, radius, from, to, steps, r = 0.3) => {
+    const pts = [];
+    for (let i = 0; i <= steps; i++) {
+      const a = from + ((to - from) * i) / steps;
+      pts.push([cx + Math.cos(a) * radius, cy + Math.sin(a) * radius]);
+    }
+    pushChain(pts, r);
+  };
+
+  const D = Math.PI / 180;
+  pushChain(L.leftWall);
+  pushChain(L.rightWall);
+  pushChain([[L.laneX, L.laneBottomY], [L.laneX, L.domeY]]);
+  pushChain([[L.outerX, L.laneBottomY], [L.outerX, L.domeY]]);
+  pushChain([[L.laneX, L.laneBottomY], [L.outerX, L.laneBottomY]]);
+  pushArc(0, L.domeY, L.domeOuterR, 0, 180 * D, 34);
+  pushArc(0, L.domeY, L.domeInnerR, 0, 130 * D, 22);
+  pushChain(L.leftGuide);
+  pushChain(L.rightGuide);
+
+  const wallGeos = wallShapes.map((s) =>
+    flatten(new THREE.ExtrudeGeometry(s, { depth: L.wallH, bevelEnabled: false }))
+  );
+  const walls = new THREE.Mesh(mergeGeometries(wallGeos), materials.rail);
+  walls.castShadow = true;
+  walls.receiveShadow = true;
+  group.add(walls);
+
+  /* ---- Slingshots (glowing rubber faces) ---- */
+  [L.leftSling, L.rightSling].forEach((s) => {
+    const geo = flatten(
+      new THREE.ExtrudeGeometry(capsuleShape(THREE, s[0][0], s[0][1], s[1][0], s[1][1], 0.32), {
+        depth: L.wallH,
+        bevelEnabled: false
+      })
+    );
+    const mesh = new THREE.Mesh(geo, materials.blueGlow);
+    mesh.castShadow = true;
+    group.add(mesh);
+    refs[s === L.leftSling ? 'leftSling' : 'rightSling'] = mesh;
+  });
+
+  /* ---- Posts ---- */
+  L.posts.forEach((p) => {
+    const post = new THREE.Mesh(
+      new THREE.CylinderGeometry(p.r, p.r, L.wallH, 16),
+      materials.gold
+    );
+    post.position.set(p.x, L.wallH / 2, -p.y);
+    post.castShadow = true;
+    group.add(post);
+  });
+
+  /* ---- Pop bumpers ---- */
+  const trophyGeo = trophyGeometry(THREE);
+  L.bumpers.forEach((b) => {
+    const g = new THREE.Group();
+    g.position.set(b.x, 0, -b.y);
+
+    const skirt = new THREE.Mesh(
+      new THREE.CylinderGeometry(L.bumperR, L.bumperR * 1.05, 0.5, 28),
+      materials.rubber
+    );
+    skirt.position.y = 0.25;
+    skirt.castShadow = true;
+    g.add(skirt);
+
+    const ring = new THREE.Mesh(
+      new THREE.TorusGeometry(L.bumperR * 0.92, 0.15, 12, 32),
+      materials.goldGlow
+    );
+    ring.rotation.x = Math.PI / 2;
+    ring.position.y = 0.56;
+    g.add(ring);
+
+    const cap = new THREE.Mesh(
+      new THREE.CylinderGeometry(L.bumperR * 0.72, L.bumperR * 0.86, 0.34, 24),
+      materials.gold
+    );
+    cap.position.y = 0.78;
+    cap.castShadow = true;
+    g.add(cap);
+
+    const trophy = new THREE.Mesh(trophyGeo, materials.goldGlow);
+    trophy.scale.setScalar(0.78);
+    trophy.position.y = 0.95;
+    g.add(trophy);
+
+    const light = new THREE.PointLight(0xf2c14e, 0, 7, 2);
+    light.position.y = 1.6;
+    g.add(light);
+
+    group.add(g);
+    refs.bumpers.push({ group: g, ring, trophy, light, base: 0 });
+  });
+
+  /* ---- Drop targets ---- */
+  L.targets.forEach((t) => {
+    const g = new THREE.Group();
+    g.position.set(t.x, 0, -t.y);
+    const face = new THREE.Mesh(
+      new THREE.BoxGeometry(t.half * 2, 1.15, 0.42),
+      materials.targetUp.clone()
+    );
+    face.position.y = 0.58;
+    face.castShadow = true;
+    g.add(face);
+    group.add(g);
+    refs.targets.push({ group: g, face, down: false });
+  });
+
+  /* ---- Jackpot trophy ---- */
+  {
+    const g = new THREE.Group();
+    g.position.set(L.jackpot.x, 0, -L.jackpot.y);
+
+    const base = new THREE.Mesh(
+      new THREE.CylinderGeometry(L.jackpot.r, L.jackpot.r * 1.1, 0.42, 26),
+      materials.rubber
+    );
+    base.position.y = 0.21;
+    g.add(base);
+
+    const trophy = new THREE.Mesh(trophyGeo, materials.goldGlow);
+    trophy.scale.setScalar(1.5);
+    trophy.position.y = 0.4;
+    trophy.castShadow = true;
+    g.add(trophy);
+
+    const halo = new THREE.Mesh(
+      new THREE.TorusGeometry(L.jackpot.r * 1.25, 0.08, 10, 34),
+      materials.goldGlow
+    );
+    halo.rotation.x = Math.PI / 2;
+    halo.position.y = 0.12;
+    g.add(halo);
+
+    const light = new THREE.PointLight(0xf2c14e, 1.6, 12, 2);
+    light.position.y = 2.2;
+    g.add(light);
+
+    group.add(g);
+    refs.jackpot = { group: g, trophy, halo, light };
+  }
+
+  /* ---- Flippers ---- */
+  const flipperGeo = flatten(
+    new THREE.ExtrudeGeometry(flipperShape(THREE, L.flipperLength, 0.4, 0.28), {
+      depth: 0.85,
+      bevelEnabled: false
+    })
+  );
+  const buildFlipper = (px, py) => {
+    const g = new THREE.Group();
+    g.position.set(px, 0.06, -py);
+    const body = new THREE.Mesh(flipperGeo, materials.gold);
+    body.castShadow = true;
+    g.add(body);
+    // Rubber strip along the face
+    const strip = new THREE.Mesh(
+      flatten(
+        new THREE.ExtrudeGeometry(flipperShape(THREE, L.flipperLength, 0.43, 0.31), {
+          depth: 0.3,
+          bevelEnabled: false
+        })
+      ),
+      materials.rubber
+    );
+    strip.position.y = 0.3;
+    g.add(strip);
+    group.add(g);
+    return g;
+  };
+  refs.flippers.left = buildFlipper(L.centerX - L.flipperSpread, L.flipperY);
+  refs.flippers.right = buildFlipper(L.centerX + L.flipperSpread, L.flipperY);
+
+  /* ---- Ball ---- */
+  const ball = new THREE.Mesh(
+    new THREE.SphereGeometry(L.ballRadius, 40, 28),
+    materials.chrome
+  );
+  ball.castShadow = true;
+  group.add(ball);
+  refs.ball = ball;
+
+  /* ---- Plunger ---- */
+  {
+    const plunger = new THREE.Group();
+    const rod = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.18, 0.18, 2.4, 16),
+      materials.chrome
+    );
+    rod.rotation.x = Math.PI / 2;
+    plunger.add(rod);
+    const knob = new THREE.Mesh(new THREE.SphereGeometry(0.42, 20, 14), materials.goldGlow);
+    knob.position.z = 1.5;
+    plunger.add(knob);
+    plunger.position.set(L.laneBallX, 0.55, -L.laneBottomY + 0.6);
+    group.add(plunger);
+    refs.plunger = plunger;
+  }
+
+  return { group, refs };
+}
+
+export { mirrorX };

--- a/src/games/pinball/physics.js
+++ b/src/games/pinball/physics.js
@@ -1,0 +1,365 @@
+/**
+ * Pinball physics — 2D on the playfield plane, rendered in 3D.
+ *
+ * A pinball is a ball rolling on a tilted plane, so the simulation is 2D:
+ * (x, y) where +y points up the table. This keeps collision exact and cheap,
+ * which matters because the ball moves fast enough to tunnel through walls if
+ * you integrate carelessly.
+ *
+ * Everything is a capsule (segment + radius) or a circle. That covers walls,
+ * rails, flippers, posts and bumpers with one pair of collision routines.
+ */
+
+/* ------------------------------------------------------------------ vectors */
+
+export const len = (x, y) => Math.hypot(x, y);
+
+export function clamp(v, lo, hi) {
+  return v < lo ? lo : v > hi ? hi : v;
+}
+
+/**
+ * Closest point to (px,py) on segment a→b, returned as [x, y, t].
+ */
+export function closestOnSegment(px, py, ax, ay, bx, by) {
+  const dx = bx - ax;
+  const dy = by - ay;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq === 0) return [ax, ay, 0];
+  let t = ((px - ax) * dx + (py - ay) * dy) / lenSq;
+  t = clamp(t, 0, 1);
+  return [ax + t * dx, ay + t * dy, t];
+}
+
+/* ------------------------------------------------------------------- colliders */
+
+/**
+ * Static capsule: a segment with thickness. Walls, rails, posts (a=b).
+ */
+export function segment(ax, ay, bx, by, opts = {}) {
+  return {
+    kind: 'segment',
+    ax,
+    ay,
+    bx,
+    by,
+    radius: opts.radius ?? 0.28,
+    restitution: opts.restitution ?? 0.42,
+    friction: opts.friction ?? 0.04,
+    kick: opts.kick ?? 0,
+    id: opts.id || null,
+    onHit: opts.onHit || null,
+    enabled: true
+  };
+}
+
+export function circle(cx, cy, radius, opts = {}) {
+  return {
+    kind: 'circle',
+    cx,
+    cy,
+    radius,
+    restitution: opts.restitution ?? 0.5,
+    friction: opts.friction ?? 0.02,
+    kick: opts.kick ?? 0,
+    id: opts.id || null,
+    onHit: opts.onHit || null,
+    enabled: true
+  };
+}
+
+/**
+ * Builds a chain of segments from a list of [x, y] points.
+ */
+export function chain(points, opts = {}) {
+  const out = [];
+  for (let i = 0; i < points.length - 1; i++) {
+    out.push(
+      segment(points[i][0], points[i][1], points[i + 1][0], points[i + 1][1], opts)
+    );
+  }
+  return out;
+}
+
+/**
+ * Approximates a circular arc with segments. Angles in radians.
+ */
+export function arc(cx, cy, radius, from, to, steps, opts = {}) {
+  const pts = [];
+  for (let i = 0; i <= steps; i++) {
+    const a = from + ((to - from) * i) / steps;
+    pts.push([cx + Math.cos(a) * radius, cy + Math.sin(a) * radius]);
+  }
+  return chain(pts, opts);
+}
+
+/* -------------------------------------------------------------------- flipper */
+
+/**
+ * A flipper is a capsule that rotates about its pivot. The ball is launched by
+ * the *contact point's* velocity, not the flipper's angle, which is what makes
+ * tip shots faster than base shots — the detail that makes flippers feel real.
+ */
+export class Flipper {
+  /**
+   * @param {number} px pivot x
+   * @param {number} py pivot y
+   * @param {number} length
+   * @param {number} restAngle radians
+   * @param {number} activeAngle radians
+   */
+  constructor(px, py, length, restAngle, activeAngle, opts = {}) {
+    this.px = px;
+    this.py = py;
+    this.length = length;
+    this.restAngle = restAngle;
+    this.activeAngle = activeAngle;
+    this.angle = restAngle;
+    this.omega = 0;
+    this.pressed = false;
+    this.radius = opts.radius ?? 0.42;
+    this.restitution = opts.restitution ?? 0.36;
+    // Up-swing is much faster than the return, like a real solenoid
+    this.upSpeed = opts.upSpeed ?? 34;
+    this.downSpeed = opts.downSpeed ?? 16;
+    this.onHit = opts.onHit || null;
+    this.enabled = true;
+  }
+
+  get tipX() {
+    return this.px + Math.cos(this.angle) * this.length;
+  }
+
+  get tipY() {
+    return this.py + Math.sin(this.angle) * this.length;
+  }
+
+  update(dt) {
+    const target = this.pressed ? this.activeAngle : this.restAngle;
+    const speed = this.pressed ? this.upSpeed : this.downSpeed;
+    const prev = this.angle;
+    const diff = target - this.angle;
+    const step = speed * dt;
+
+    if (Math.abs(diff) <= step) this.angle = target;
+    else this.angle += Math.sign(diff) * step;
+
+    this.omega = dt > 0 ? (this.angle - prev) / dt : 0;
+  }
+
+  /**
+   * Resolves the ball against this flipper, including the impulse from the
+   * moving surface.
+   */
+  collide(ball) {
+    if (!this.enabled) return false;
+
+    const bx = this.tipX;
+    const by = this.tipY;
+    const [qx, qy] = closestOnSegment(ball.x, ball.y, this.px, this.py, bx, by);
+
+    let dx = ball.x - qx;
+    let dy = ball.y - qy;
+    let dist = len(dx, dy);
+    const minDist = ball.radius + this.radius;
+    if (dist >= minDist) return false;
+
+    if (dist < 1e-6) {
+      // Degenerate: push straight out from the flipper's axis
+      dx = -Math.sin(this.angle);
+      dy = Math.cos(this.angle);
+      dist = 1;
+    }
+
+    const nx = dx / dist;
+    const ny = dy / dist;
+
+    // Depenetrate
+    const pen = minDist - dist;
+    ball.x += nx * pen;
+    ball.y += ny * pen;
+
+    // Velocity of the flipper surface at the contact point: ω × r
+    const rx = qx - this.px;
+    const ry = qy - this.py;
+    const contactVx = -this.omega * ry;
+    const contactVy = this.omega * rx;
+
+    const relVx = ball.vx - contactVx;
+    const relVy = ball.vy - contactVy;
+    const vn = relVx * nx + relVy * ny;
+
+    if (vn < 0) {
+      const j = -(1 + this.restitution) * vn;
+      ball.vx += nx * j;
+      ball.vy += ny * j;
+
+      // A little tangential drag so the ball doesn't slide frictionlessly
+      const tx = -ny;
+      const ty = nx;
+      const vt = (ball.vx - contactVx) * tx + (ball.vy - contactVy) * ty;
+      ball.vx -= tx * vt * 0.08;
+      ball.vy -= ty * vt * 0.08;
+
+      if (this.onHit) this.onHit(Math.abs(vn));
+    }
+    return true;
+  }
+}
+
+/* ----------------------------------------------------------------------- ball */
+
+export class Ball {
+  constructor(radius) {
+    this.radius = radius;
+    this.x = 0;
+    this.y = 0;
+    this.vx = 0;
+    this.vy = 0;
+    this.spin = 0;
+    this.live = false;
+  }
+
+  place(x, y, vx = 0, vy = 0) {
+    this.x = x;
+    this.y = y;
+    this.vx = vx;
+    this.vy = vy;
+  }
+
+  get speed() {
+    return len(this.vx, this.vy);
+  }
+}
+
+/* ---------------------------------------------------------------------- world */
+
+export class World {
+  constructor(opts = {}) {
+    this.colliders = [];
+    this.flippers = [];
+    this.gravity = opts.gravity ?? 26;
+    this.damping = opts.damping ?? 0.16;
+    this.maxSpeed = opts.maxSpeed ?? 62;
+    this.nudgeX = 0;
+    this.nudgeY = 0;
+  }
+
+  add(collider) {
+    if (Array.isArray(collider)) this.colliders.push(...collider);
+    else this.colliders.push(collider);
+    return collider;
+  }
+
+  addFlipper(f) {
+    this.flippers.push(f);
+    return f;
+  }
+
+  /**
+   * Advances the simulation. Splits dt into substeps sized so the ball can
+   * never move more than a fraction of its radius per step — without this a
+   * hard shot passes straight through a wall.
+   */
+  step(ball, dt) {
+    const speed = Math.max(ball.speed, 1);
+    const steps = clamp(Math.ceil((speed * dt) / (ball.radius * 0.35)), 1, 24);
+    const sdt = dt / steps;
+
+    for (let i = 0; i < steps; i++) {
+      this.flippers.forEach((f) => f.update(sdt));
+      if (ball.live) this.integrate(ball, sdt);
+    }
+  }
+
+  integrate(ball, dt) {
+    // Gravity down the inclined playfield, plus any nudge impulse
+    ball.vy -= this.gravity * dt;
+    ball.vx += this.nudgeX * dt;
+    ball.vy += this.nudgeY * dt;
+
+    // Mild rolling resistance
+    const d = Math.max(0, 1 - this.damping * dt);
+    ball.vx *= d;
+    ball.vy *= d;
+
+    const sp = ball.speed;
+    if (sp > this.maxSpeed) {
+      ball.vx = (ball.vx / sp) * this.maxSpeed;
+      ball.vy = (ball.vy / sp) * this.maxSpeed;
+    }
+
+    ball.x += ball.vx * dt;
+    ball.y += ball.vy * dt;
+
+    // Static geometry, then flippers (so a flipper always wins a fight
+    // between it and the wall behind it)
+    for (let i = 0; i < this.colliders.length; i++) {
+      const c = this.colliders[i];
+      if (c.enabled) this.resolve(ball, c);
+    }
+    for (let i = 0; i < this.flippers.length; i++) {
+      this.flippers[i].collide(ball);
+    }
+
+    // Collisions add energy (bumper kicks, flipper impulses), so clamp again —
+    // otherwise a hard flipper hit can outrun the substep budget and tunnel.
+    const post = ball.speed;
+    if (post > this.maxSpeed) {
+      ball.vx = (ball.vx / post) * this.maxSpeed;
+      ball.vy = (ball.vy / post) * this.maxSpeed;
+    }
+  }
+
+  resolve(ball, c) {
+    let qx;
+    let qy;
+
+    if (c.kind === 'segment') {
+      const p = closestOnSegment(ball.x, ball.y, c.ax, c.ay, c.bx, c.by);
+      qx = p[0];
+      qy = p[1];
+    } else {
+      qx = c.cx;
+      qy = c.cy;
+    }
+
+    let dx = ball.x - qx;
+    let dy = ball.y - qy;
+    let dist = len(dx, dy);
+    const minDist = ball.radius + c.radius;
+    if (dist >= minDist) return false;
+
+    if (dist < 1e-6) {
+      dx = 0;
+      dy = 1;
+      dist = 1;
+    }
+
+    const nx = dx / dist;
+    const ny = dy / dist;
+
+    ball.x += nx * (minDist - dist);
+    ball.y += ny * (minDist - dist);
+
+    const vn = ball.vx * nx + ball.vy * ny;
+    if (vn < 0) {
+      const j = -(1 + c.restitution) * vn;
+      ball.vx += nx * j;
+      ball.vy += ny * j;
+
+      const tx = -ny;
+      const ty = nx;
+      const vt = ball.vx * tx + ball.vy * ty;
+      ball.vx -= tx * vt * c.friction;
+      ball.vy -= ty * vt * c.friction;
+
+      if (c.kick) {
+        ball.vx += nx * c.kick;
+        ball.vy += ny * c.kick;
+      }
+      if (c.onHit) c.onHit(Math.abs(vn), ball);
+    }
+    return true;
+  }
+}

--- a/src/games/pinball/table.js
+++ b/src/games/pinball/table.js
@@ -1,0 +1,403 @@
+/**
+ * Pekkas Pokal — table layout.
+ *
+ * One source of truth: the same numbers build the physics colliders and the
+ * 3D geometry, so what you see is exactly what the ball hits.
+ *
+ * Playfield coordinates: +y runs up the table, the drain is at y = 0.
+ * The shooter lane is on the right, feeding a habitrail around the top dome.
+ */
+
+import { segment, circle, chain, arc, Flipper } from './physics.js';
+
+const D = Math.PI / 180;
+
+export const L = {
+  // Outer bounds
+  outerX: 9,
+  domeY: 31,
+  domeOuterR: 9,
+  // Inner radius and divider leave a 1.8 channel — comfortably wider than the
+  // 1.24 ball. Any narrower and the ball wedges in the shooter lane.
+  domeInnerR: 6.6,
+
+  // Shooter lane
+  laneX: 6.6,
+  laneBallX: 7.8,
+  laneBottomY: 2,
+  laneWallR: 0.3,
+
+  // Playfield proper spans -9 .. 6.6
+  centerX: -1.2,
+
+  ballRadius: 0.62,
+
+  // Flippers
+  flipperY: 7,
+  flipperSpread: 3.7,
+  flipperLength: 3.0,
+  flipperRest: -30 * D,
+  flipperSwing: 62 * D,
+
+  // Slingshots (kicking face, outer → inner)
+  slingTopY: 12.4,
+  slingBotY: 8.4,
+
+  // Bumpers
+  bumperR: 1.25,
+
+  wallH: 1.5
+};
+
+L.bumpers = [
+  { x: L.centerX - 3.3, y: 26.4 },
+  { x: L.centerX + 3.3, y: 26.4 },
+  { x: L.centerX, y: 29.0 }
+];
+
+// P-O-K-A-L drop target bank, with an open orbit lane either side
+L.targets = ['P', 'O', 'K', 'A', 'L'].map((letter, i) => ({
+  letter,
+  x: L.centerX - 4.5 + i * 2.25,
+  y: 19,
+  half: 0.62
+}));
+
+L.jackpot = { x: L.centerX, y: 32.9, r: 1.05 };
+
+L.posts = [
+  { x: L.centerX - 3.4, y: 14.6, r: 0.34 },
+  { x: L.centerX + 3.4, y: 14.6, r: 0.34 },
+  { x: L.centerX, y: 23.2, r: 0.3 },
+  { x: L.centerX - 5.2, y: 22.6, r: 0.3 },
+  { x: L.centerX + 5.2, y: 22.6, r: 0.3 }
+];
+
+/* ------------------------------------------------------------ wall polylines */
+
+const mirrorX = (x) => 2 * L.centerX - x;
+
+// Left outer wall down into the outlane and drain funnel
+L.leftWall = [
+  [-L.outerX, L.domeY],
+  [-L.outerX, 9],
+  [-7.8, 4.2],
+  [-3.3, -1.4]
+];
+
+L.rightWall = [
+  [L.laneX, L.domeY],
+  [L.laneX, 9],
+  [mirrorX(-7.8), 4.2],
+  [mirrorX(-3.3), -1.4]
+];
+
+// Slingshot faces — the ball is kicked along the face normal, toward centre
+L.leftSling = [
+  [-7.6, L.slingTopY],
+  [-5.0, L.slingBotY]
+];
+L.rightSling = [
+  [mirrorX(-7.6), L.slingTopY],
+  [mirrorX(-5.0), L.slingBotY]
+];
+
+// Inlane/outlane dividers, guiding returns onto the flippers
+L.leftGuide = [
+  [-5.0, L.slingBotY],
+  [-5.5, 5.2]
+];
+L.rightGuide = [
+  [mirrorX(-5.0), L.slingBotY],
+  [mirrorX(-5.5), 5.2]
+];
+
+/* ------------------------------------------------------------------ colliders */
+
+/**
+ * Builds every collider and flipper into `world`.
+ * `hooks` receives gameplay events: onBumper, onSling, onTarget, onJackpot,
+ * onWall, onOrbit.
+ */
+export function buildColliders(world, hooks = {}) {
+  const refs = { targets: [], bumpers: [], flippers: {}, orbitGates: [] };
+  const wallOpts = { radius: 0.3, restitution: 0.4, friction: 0.05 };
+  const hitWall = (v) => hooks.onWall && hooks.onWall(v);
+
+  // Outer shell
+  world.add(chain(L.leftWall, { ...wallOpts, onHit: hitWall }));
+  world.add(chain(L.rightWall, { ...wallOpts, onHit: hitWall }));
+
+  // Shooter lane: divider up to the dome, then the inner habitrail arc
+  world.add(segment(L.laneX, L.laneBottomY, L.laneX, L.domeY, wallOpts));
+  world.add(arc(0, L.domeY, L.domeInnerR, 0, 130 * D, 22, wallOpts));
+
+  // Outer dome
+  world.add(arc(0, L.domeY, L.domeOuterR, 0, 180 * D, 34, { ...wallOpts, onHit: hitWall }));
+  world.add(segment(L.outerX, L.laneBottomY, L.outerX, L.domeY, wallOpts));
+
+  // Shooter lane floor
+  world.add(
+    segment(L.laneX, L.laneBottomY, L.outerX, L.laneBottomY, { ...wallOpts, restitution: 0.15 })
+  );
+
+  // Slingshots — strong kick, awards points
+  const slingOpts = (side) => ({
+    radius: 0.32,
+    restitution: 0.62,
+    kick: 13,
+    onHit: (v) => hooks.onSling && hooks.onSling(side, v)
+  });
+  world.add(chain(L.leftSling, slingOpts('left')));
+  world.add(chain(L.rightSling, slingOpts('right')));
+
+  // Return guides
+  world.add(chain(L.leftGuide, wallOpts));
+  world.add(chain(L.rightGuide, wallOpts));
+
+  // Pop bumpers
+  L.bumpers.forEach((b, i) => {
+    const c = circle(b.x, b.y, L.bumperR, {
+      restitution: 0.52,
+      kick: 17,
+      id: `bumper${i}`,
+      onHit: (v) => hooks.onBumper && hooks.onBumper(i, v)
+    });
+    world.add(c);
+    refs.bumpers.push(c);
+  });
+
+  // P-O-K-A-L drop targets
+  L.targets.forEach((t, i) => {
+    const c = segment(t.x - t.half, t.y, t.x + t.half, t.y, {
+      radius: 0.26,
+      restitution: 0.34,
+      id: `target${i}`,
+      onHit: (v) => hooks.onTarget && hooks.onTarget(i, v)
+    });
+    world.add(c);
+    refs.targets.push(c);
+  });
+
+  // Jackpot trophy
+  const jack = circle(L.jackpot.x, L.jackpot.y, L.jackpot.r, {
+    restitution: 0.55,
+    kick: 8,
+    id: 'jackpot',
+    onHit: (v) => hooks.onJackpot && hooks.onJackpot(v)
+  });
+  world.add(jack);
+  refs.jackpot = jack;
+
+  // Decorative posts
+  L.posts.forEach((p) => {
+    world.add(circle(p.x, p.y, p.r, { restitution: 0.55, onHit: hitWall }));
+  });
+
+  // Flippers
+  const lp = L.centerX - L.flipperSpread;
+  const rp = L.centerX + L.flipperSpread;
+  refs.flippers.left = world.addFlipper(
+    new Flipper(lp, L.flipperY, L.flipperLength, L.flipperRest, L.flipperRest + L.flipperSwing, {
+      radius: 0.4,
+      onHit: (v) => hooks.onFlipper && hooks.onFlipper('left', v)
+    })
+  );
+  refs.flippers.right = world.addFlipper(
+    new Flipper(
+      rp,
+      L.flipperY,
+      L.flipperLength,
+      Math.PI - L.flipperRest,
+      Math.PI - L.flipperRest - L.flipperSwing,
+      {
+        radius: 0.4,
+        onHit: (v) => hooks.onFlipper && hooks.onFlipper('right', v)
+      }
+    )
+  );
+
+  return refs;
+}
+
+/* ------------------------------------------------------- playfield artwork */
+
+const TEX_W = 1024;
+const TEX_H = 2048;
+// Region of playfield space the texture covers
+const ART = { x0: -L.outerX - 0.6, x1: L.outerX + 0.6, y0: -2, y1: 42 };
+
+const toU = (x) => ((x - ART.x0) / (ART.x1 - ART.x0)) * TEX_W;
+const toV = (y) => TEX_H - ((y - ART.y0) / (ART.y1 - ART.y0)) * TEX_H;
+
+/**
+ * Draws the playfield art to a canvas. Doing this procedurally keeps the game
+ * asset-free while still looking designed rather than bare.
+ */
+export function createPlayfieldCanvas(participants = []) {
+  const cv = document.createElement('canvas');
+  cv.width = TEX_W;
+  cv.height = TEX_H;
+  const g = cv.getContext('2d');
+
+  const GOLD = '#f2c14e';
+  const GOLD_DIM = 'rgba(242,193,78,.35)';
+
+  // Base
+  const base = g.createLinearGradient(0, 0, 0, TEX_H);
+  base.addColorStop(0, '#141a33');
+  base.addColorStop(0.45, '#0e1226');
+  base.addColorStop(1, '#171d3a');
+  g.fillStyle = base;
+  g.fillRect(0, 0, TEX_W, TEX_H);
+
+  // Vignette glow behind the bumpers
+  const glow = g.createRadialGradient(toU(-0.9), toV(28), 20, toU(-0.9), toV(28), 420);
+  glow.addColorStop(0, 'rgba(124,140,248,.20)');
+  glow.addColorStop(1, 'rgba(124,140,248,0)');
+  g.fillStyle = glow;
+  g.fillRect(0, 0, TEX_W, TEX_H);
+
+  const glow2 = g.createRadialGradient(toU(-0.9), toV(8), 20, toU(-0.9), toV(8), 380);
+  glow2.addColorStop(0, 'rgba(242,193,78,.16)');
+  glow2.addColorStop(1, 'rgba(242,193,78,0)');
+  g.fillStyle = glow2;
+  g.fillRect(0, 0, TEX_W, TEX_H);
+
+  // Concentric arcs echoing the dome
+  g.strokeStyle = GOLD_DIM;
+  g.lineWidth = 2;
+  for (let r = 3; r <= 8.4; r += 1.35) {
+    g.beginPath();
+    const rx = (r / (ART.x1 - ART.x0)) * TEX_W;
+    const ry = (r / (ART.y1 - ART.y0)) * TEX_H;
+    g.ellipse(toU(0), toV(L.domeY), rx, ry, 0, Math.PI, 2 * Math.PI);
+    g.stroke();
+  }
+
+  // Orbit lane guides beside the target bank
+  g.strokeStyle = 'rgba(124,140,248,.30)';
+  g.lineWidth = 5;
+  [[-7.6, 12, -7.6, 24], [L.laneX - 1.2, 12, L.laneX - 1.2, 24]].forEach(([x0, y0, x1, y1]) => {
+    g.beginPath();
+    g.moveTo(toU(x0), toV(y0));
+    g.lineTo(toU(x1), toV(y1));
+    g.stroke();
+  });
+
+  // Inlane arrows pointing at the flippers
+  g.fillStyle = 'rgba(242,193,78,.30)';
+  [-1, 1].forEach((s) => {
+    const cx = L.centerX + s * 4.3;
+    for (let i = 0; i < 3; i++) {
+      const y = 11.5 - i * 1.3;
+      g.beginPath();
+      g.moveTo(toU(cx - 0.55), toV(y));
+      g.lineTo(toU(cx + 0.55), toV(y));
+      g.lineTo(toU(cx), toV(y - 0.75));
+      g.closePath();
+      g.fill();
+    }
+  });
+
+  // Title arc across the top
+  g.save();
+  g.translate(toU(0), toV(L.domeY + 4.7));
+  g.fillStyle = GOLD;
+  g.font = '700 42px "Space Grotesk", Inter, sans-serif';
+  g.textAlign = 'center';
+  g.textBaseline = 'middle';
+  g.shadowColor = 'rgba(242,193,78,.6)';
+  g.shadowBlur = 20;
+  g.fillText('PEKKAS POKAL', 0, 0);
+  g.shadowBlur = 0;
+  g.font = '600 22px Inter, sans-serif';
+  g.fillStyle = 'rgba(255,255,255,.5)';
+  g.letterSpacing = '8px';
+  g.fillText('FLIPPER · 2025', 0, 38);
+  g.restore();
+
+  // Target bank label
+  g.fillStyle = 'rgba(255,255,255,.32)';
+  g.font = '700 26px Inter, sans-serif';
+  g.textAlign = 'center';
+  g.letterSpacing = '6px';
+  g.fillText('SLÅ NER ALLA FEM', toU(L.centerX), toV(21.4));
+  g.letterSpacing = '0px';
+
+  // Jackpot ring
+  g.strokeStyle = GOLD;
+  g.lineWidth = 4;
+  g.setLineDash([14, 10]);
+  g.beginPath();
+  g.ellipse(
+    toU(L.jackpot.x),
+    toV(L.jackpot.y),
+    (2.1 / (ART.x1 - ART.x0)) * TEX_W,
+    (2.1 / (ART.y1 - ART.y0)) * TEX_H,
+    0,
+    0,
+    Math.PI * 2
+  );
+  g.stroke();
+  g.setLineDash([]);
+
+  // Roll of honour down the left edge — the people this table is about
+  if (participants.length) {
+    g.save();
+    g.fillStyle = 'rgba(255,255,255,.14)';
+    g.font = '600 19px Inter, sans-serif';
+    g.textAlign = 'left';
+    participants.slice(0, 13).forEach((name, i) => {
+      g.fillText(name.toUpperCase(), toU(-8.75), toV(24.5 - i * 0.92));
+    });
+    g.restore();
+  }
+
+  // Shooter lane stripe
+  g.fillStyle = 'rgba(242,193,78,.10)';
+  g.fillRect(toU(L.laneX), toV(L.domeY), toU(L.outerX) - toU(L.laneX), toV(2) - toV(L.domeY));
+
+  g.save();
+  g.translate(toU((L.laneX + L.outerX) / 2), toV(16));
+  g.rotate(-Math.PI / 2);
+  g.fillStyle = 'rgba(242,193,78,.5)';
+  g.font = '700 26px Inter, sans-serif';
+  g.textAlign = 'center';
+  g.letterSpacing = '8px';
+  g.fillText('DRA OCH SLÄPP', 0, 8);
+  g.restore();
+
+  // Drain warning
+  g.fillStyle = 'rgba(242,109,141,.35)';
+  g.font = '700 22px Inter, sans-serif';
+  g.textAlign = 'center';
+  g.letterSpacing = '5px';
+  g.fillText('UTGÅNG', toU(L.centerX), toV(1.2));
+
+  // Subtle grain so large flat areas aren't dead. Built on its own canvas and
+  // drawn with drawImage — putImageData REPLACES pixels rather than compositing,
+  // which would erase everything above.
+  const gc = document.createElement('canvas');
+  gc.width = 128;
+  gc.height = 128;
+  const gg = gc.getContext('2d');
+  const grain = gg.createImageData(128, 128);
+  for (let i = 0; i < grain.data.length; i += 4) {
+    grain.data[i] = 255;
+    grain.data[i + 1] = 255;
+    grain.data[i + 2] = 255;
+    grain.data[i + 3] = Math.random() * 26;
+  }
+  gg.putImageData(grain, 0, 0);
+  g.save();
+  g.globalAlpha = 0.5;
+  for (let y = 0; y < TEX_H; y += 128) {
+    for (let x = 0; x < TEX_W; x += 128) g.drawImage(gc, x, y);
+  }
+  g.restore();
+
+  return { canvas: cv, art: ART };
+}
+
+export { ART, mirrorX, D };

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -98,7 +98,8 @@
     achCategory: 'all',
     currentView: 'overview',
     modalChart: null,
-    lastFocus: null
+    lastFocus: null,
+    game: null
   };
 
   /* ======================================================================
@@ -1856,6 +1857,105 @@
   }
 
   /* ======================================================================
+     Rendering — Spel
+     ====================================================================== */
+
+  /**
+   * One game per year. Entries without a `module` render as coming soon —
+   * add one here as each year's game gets built.
+   */
+  const GAMES = [
+    {
+      year: 2025,
+      title: 'Pekkas Pokal Flipper',
+      competition: 'Flipper',
+      tagline: 'Ett fullstort flipperspel i 3D. Tre bollar, fem mål och en pokal.',
+      icon: '🎯',
+      module: 'src/games/pinball/index.js'
+    }
+  ];
+
+  function renderGames() {
+    const byYear = {};
+    GAMES.forEach((g) => (byYear[g.year] = g));
+
+    const cards = App.data.competitions
+      .filter((c) => !c.isCovid && c.participantCount > 0)
+      .map((comp) => {
+        const game = byYear[comp.year];
+        if (game) {
+          return `
+          <button class="game-card playable" data-game="${comp.year}">
+            <span class="game-badge">Spelbar</span>
+            <span class="game-icon">${game.icon}</span>
+            <span class="game-year">${comp.year}</span>
+            <span class="game-title">${esc(game.title)}</span>
+            <span class="game-tagline">${esc(game.tagline)}</span>
+            <span class="game-play">Spela nu →</span>
+          </button>`;
+        }
+        return `
+        <div class="game-card soon">
+          <span class="game-icon">🔒</span>
+          <span class="game-year">${comp.year}</span>
+          <span class="game-title">${esc(comp.name.trim())}</span>
+          <span class="game-tagline">Spelet för det här året är inte byggt än.</span>
+        </div>`;
+      })
+      .join('');
+
+    $('#game-grid').innerHTML = cards;
+
+    $('#game-grid').addEventListener('click', (e) => {
+      const card = e.target.closest('[data-game]');
+      if (card) launchGame(Number(card.getAttribute('data-game')));
+    });
+    $('#game-close').addEventListener('click', closeGame);
+  }
+
+  async function launchGame(year) {
+    const game = GAMES.find((g) => g.year === year);
+    if (!game || App.game) return;
+
+    const stage = $('#game-stage');
+    const loading = $('#game-loading');
+    stage.hidden = false;
+    loading.hidden = false;
+    document.body.classList.add('game-open');
+
+    try {
+      const url = new URL(game.module, document.baseURI).href;
+      const mod = await import(/* @vite-ignore */ url);
+      const create = mod.createPinball || mod.default;
+      App.game = await create($('#game-mount'), {
+        participants: App.data.participants
+          .filter((p) => App.stats.per[p.id].starts > 0)
+          .map((p) => p.name)
+      });
+      loading.hidden = true;
+    } catch (err) {
+      console.error('Game failed to load:', err);
+      $('#game-loading-text').textContent =
+        'Kunde inte ladda spelet. Kontrollera nätverket och försök igen.';
+      $('.game-spinner').style.display = 'none';
+    }
+  }
+
+  function closeGame() {
+    if (App.game) {
+      App.game.destroy();
+      App.game = null;
+    }
+    $('#game-mount').innerHTML = '';
+    $('#game-stage').hidden = true;
+    $('#game-loading').hidden = false;
+    const spinner = $('.game-spinner');
+    if (spinner) spinner.style.display = '';
+    $('#game-loading-text').textContent = 'Bygger bordet…';
+    document.body.classList.remove('game-open');
+  }
+
+  /* ======================================================================
      Modal — participant profiles & year details
      ====================================================================== */
 
@@ -2090,7 +2190,9 @@
       if (e.target === $('#modal')) closeModal();
     });
     document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') closeModal();
+      if (e.key !== 'Escape') return;
+      if (App.game) closeGame();
+      else closeModal();
     });
 
     // Delegated: any person link or year row anywhere in the app
@@ -2125,6 +2227,7 @@
 
     // Leaflet needs a size refresh when its container becomes visible
     if (id === 'overview' && App.map) setTimeout(() => App.map.invalidateSize(), 60);
+    if (id !== 'games' && App.game) closeGame();
 
     observeReveals();
   }
@@ -2149,7 +2252,7 @@
     window.addEventListener('resize', positionNavIndicator);
 
     const hash = location.hash.replace('#', '');
-    if (['overview', 'medals', 'history', 'achievements', 'stats'].includes(hash)) {
+    if (['overview', 'medals', 'history', 'achievements', 'stats', 'games'].includes(hash)) {
       App.currentView = hash;
     }
   }
@@ -2220,6 +2323,7 @@
       renderStatsView();
       renderH2HControls();
       renderElo();
+      renderGames();
       initMap();
 
       $('#theme-toggle').addEventListener('click', toggleTheme);

--- a/src/styles/games.css
+++ b/src/styles/games.css
@@ -1,0 +1,593 @@
+/* ==========================================================================
+   Pekkas Pokal — Spel: year grid, game stage, pinball HUD
+   ========================================================================== */
+
+/* ---------------------------------------------------------------- year grid */
+
+.game-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(260px, 100%), 1fr));
+  gap: var(--sp-4);
+}
+
+.game-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--sp-1);
+  padding: var(--sp-5);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  backdrop-filter: var(--card-blur);
+  -webkit-backdrop-filter: var(--card-blur);
+  text-align: left;
+  overflow: hidden;
+  transition: transform var(--t-med) var(--ease-out), border-color var(--t-med),
+    box-shadow var(--t-med);
+}
+
+.game-card.playable {
+  cursor: pointer;
+  border-color: color-mix(in srgb, var(--gold) 40%, var(--border));
+  box-shadow: var(--shadow-1), var(--glow-gold);
+}
+
+.game-card.playable::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 90% at 80% 0%, rgba(242, 193, 78, 0.16), transparent 60%);
+  pointer-events: none;
+}
+
+.game-card.playable:hover {
+  transform: translateY(-4px);
+}
+
+.game-card.playable:active {
+  transform: translateY(-1px) scale(0.99);
+}
+
+.game-card.soon {
+  opacity: 0.55;
+}
+
+.game-badge {
+  position: absolute;
+  top: var(--sp-4);
+  right: var(--sp-4);
+  padding: 3px 10px;
+  border-radius: var(--r-pill);
+  background: linear-gradient(140deg, var(--gold), var(--gold-deep));
+  color: var(--accent-contrast);
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.game-icon {
+  font-size: 1.9rem;
+  line-height: 1;
+  margin-bottom: var(--sp-2);
+}
+
+.game-year {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: var(--text-sm);
+  letter-spacing: 0.1em;
+  color: var(--accent);
+}
+
+.game-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: var(--text-lg);
+  line-height: 1.2;
+}
+
+.game-tagline {
+  margin-top: 2px;
+  font-size: var(--text-sm);
+  color: var(--text-2);
+}
+
+.game-play {
+  margin-top: var(--sp-3);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: var(--accent);
+  transition: transform var(--t-fast);
+}
+
+.game-card.playable:hover .game-play {
+  transform: translateX(3px);
+}
+
+/* --------------------------------------------------------------- game stage */
+
+body.game-open {
+  overflow: hidden;
+}
+
+.game-stage {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  background: #05070f;
+  display: flex;
+  overscroll-behavior: none;
+}
+
+.game-stage[hidden] {
+  display: none;
+}
+
+.game-mount {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.game-close {
+  position: absolute;
+  top: max(12px, env(safe-area-inset-top));
+  right: 12px;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  color: #cfd6f5;
+  background: rgba(12, 16, 32, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  backdrop-filter: blur(8px);
+  transition: color var(--t-fast), transform var(--t-fast);
+}
+
+.game-close:hover {
+  color: var(--gold);
+  transform: rotate(90deg);
+}
+
+.game-loading {
+  position: absolute;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-4);
+  background: #05070f;
+  color: #a7aecb;
+  font-size: var(--text-sm);
+  text-align: center;
+  padding: var(--sp-5);
+}
+
+.game-loading[hidden] {
+  display: none;
+}
+
+.game-spinner {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 3px solid rgba(242, 193, 78, 0.22);
+  border-top-color: #f2c14e;
+  animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ------------------------------------------------------------- pinball view */
+
+.pb-canvas {
+  position: absolute;
+  inset: 0;
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+}
+
+.pb-canvas canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* The UI layer is click-through except for its own controls */
+.pb-ui {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  font-family: var(--font-body);
+  color: #eef1ff;
+}
+
+.pb-ui button {
+  pointer-events: auto;
+}
+
+/* ---- Top bar ---- */
+
+.pb-top {
+  position: absolute;
+  top: max(10px, env(safe-area-inset-top));
+  left: 12px;
+  right: 62px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--sp-4);
+}
+
+.pb-score {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(1.7rem, 7vw, 2.6rem);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  color: #fff;
+  text-shadow: 0 0 22px rgba(242, 193, 78, 0.55);
+}
+
+.pb-hi {
+  margin-top: 2px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: rgba(190, 199, 233, 0.65);
+}
+
+.pb-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.pb-mult {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.15rem;
+  color: #f2c14e;
+  text-shadow: 0 0 16px rgba(242, 193, 78, 0.6);
+}
+
+.pb-balls {
+  display: flex;
+  gap: 5px;
+}
+
+.pb-ball-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+
+.pb-ball-dot.on {
+  background: linear-gradient(140deg, #fff, #b9c2e8);
+  box-shadow: 0 0 10px rgba(210, 220, 255, 0.75);
+}
+
+/* ---- P-O-K-A-L progress ---- */
+
+.pb-pokal {
+  position: absolute;
+  top: calc(max(10px, env(safe-area-inset-top)) + 62px);
+  left: 12px;
+  display: flex;
+  gap: 5px;
+}
+
+.pb-letter {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: rgba(190, 199, 233, 0.5);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: all var(--t-med) var(--ease-spring);
+}
+
+.pb-letter.lit {
+  color: #241a05;
+  background: linear-gradient(140deg, #f2c14e, #d99a2b);
+  border-color: transparent;
+  box-shadow: 0 0 14px rgba(242, 193, 78, 0.7);
+  transform: translateY(-2px);
+}
+
+/* ---- Toast ---- */
+
+.pb-toast {
+  position: absolute;
+  left: 50%;
+  top: 26%;
+  transform: translate(-50%, -6px);
+  padding: 0.5rem 1.1rem;
+  border-radius: var(--r-pill);
+  background: rgba(10, 14, 28, 0.78);
+  border: 1px solid rgba(242, 193, 78, 0.34);
+  backdrop-filter: blur(8px);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity var(--t-med), transform var(--t-med) var(--ease-out);
+}
+
+.pb-toast.show {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.pb-toast.big {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  color: #f2c14e;
+  border-color: rgba(242, 193, 78, 0.7);
+  box-shadow: 0 0 34px rgba(242, 193, 78, 0.35);
+}
+
+/* ---- Overlay ---- */
+
+.pb-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--sp-5);
+  background: rgba(5, 7, 15, 0.82);
+  backdrop-filter: blur(10px);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--t-med), visibility var(--t-med);
+}
+
+.pb-overlay.show {
+  opacity: 1;
+  visibility: visible;
+}
+
+.pb-panel {
+  max-width: 380px;
+  text-align: center;
+  color: #eef1ff;
+}
+
+.pb-panel h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.5rem, 6vw, 2rem);
+  font-weight: 700;
+  background: linear-gradient(120deg, #f2c14e, #fff0c8 55%, #d99a2b);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.pb-panel p {
+  margin-top: var(--sp-3);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: #a7aecb;
+}
+
+.pb-scoreline {
+  margin-top: var(--sp-4);
+}
+
+.pb-scoreline span {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 2.4rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: #fff;
+}
+
+.pb-scoreline small {
+  display: block;
+  margin-top: 2px;
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(190, 199, 233, 0.6);
+}
+
+.pb-btn {
+  margin-top: var(--sp-5);
+  padding: 0.8rem 2rem;
+  border-radius: var(--r-pill);
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #241a05;
+  background: linear-gradient(140deg, #f2c14e, #d99a2b);
+  border: none;
+  box-shadow: 0 8px 26px rgba(242, 193, 78, 0.36);
+  transition: transform var(--t-fast) var(--ease-out), box-shadow var(--t-fast);
+}
+
+.pb-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 32px rgba(242, 193, 78, 0.46);
+}
+
+.pb-btn:active {
+  transform: scale(0.97);
+}
+
+/* ---- Plunger ---- */
+
+.pb-plunger {
+  position: absolute;
+  left: 50%;
+  bottom: calc(18px + env(safe-area-inset-bottom));
+  transform: translateX(-50%);
+  width: min(300px, 76vw);
+  text-align: center;
+  pointer-events: none;
+}
+
+.pb-plunger[hidden] {
+  display: none;
+}
+
+.pb-plunger-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(190, 199, 233, 0.8);
+  margin-bottom: 8px;
+  animation: pb-breathe 2s ease-in-out infinite;
+}
+
+@keyframes pb-breathe {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+
+.pb-power {
+  height: 12px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.09);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  overflow: hidden;
+}
+
+.pb-power span {
+  display: block;
+  height: 100%;
+  width: 0;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #d99a2b, #f2c14e, #fff0c8);
+  box-shadow: 0 0 18px rgba(242, 193, 78, 0.7);
+}
+
+/* ---- Nudge + mute ---- */
+
+.pb-controls {
+  position: absolute;
+  left: 50%;
+  bottom: calc(14px + env(safe-area-inset-bottom));
+  transform: translateX(-50%);
+  z-index: 15;
+}
+
+.pb-controls[hidden] {
+  display: none;
+}
+
+.pb-nudge {
+  padding: 0.5rem 1.5rem;
+  border-radius: var(--r-pill);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: rgba(220, 226, 250, 0.9);
+  background: rgba(12, 16, 32, 0.62);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  backdrop-filter: blur(8px);
+  transition: color var(--t-fast), border-color var(--t-fast), transform var(--t-fast);
+}
+
+.pb-nudge:active {
+  transform: scale(0.94);
+  color: #f2c14e;
+  border-color: rgba(242, 193, 78, 0.6);
+}
+
+.pb-mute {
+  position: absolute;
+  top: max(12px, env(safe-area-inset-top));
+  right: 60px;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  color: rgba(220, 226, 250, 0.85);
+  background: rgba(12, 16, 32, 0.62);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  backdrop-filter: blur(8px);
+  pointer-events: auto;
+}
+
+.pb-mute.off {
+  color: rgba(190, 199, 233, 0.4);
+}
+
+.pb-mute.off .pb-wave {
+  display: none;
+}
+
+/* ---- Landscape / desktop: keep the table portrait and centred ---- */
+
+@media (min-aspect-ratio: 1/1) {
+  .game-mount {
+    max-width: min(56vh, 100%);
+    margin: 0 auto;
+  }
+
+  .game-stage {
+    background:
+      radial-gradient(80% 60% at 50% 0%, rgba(124, 140, 248, 0.08), transparent 70%),
+      #05070f;
+  }
+}
+
+@media (max-width: 420px) {
+  .pb-letter {
+    width: 20px;
+    height: 20px;
+    font-size: 0.62rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pb-plunger-label {
+    animation: none;
+    opacity: 0.9;
+  }
+}
+
+/* Skill-shot band on the plunger meter */
+.pb-power {
+  position: relative;
+}
+
+.pb-skill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 68%;
+  width: 18%;
+  background: rgba(79, 209, 197, 0.5);
+  box-shadow: 0 0 12px rgba(79, 209, 197, 0.7);
+}
+
+.pb-power span {
+  position: relative;
+  z-index: 1;
+}


### PR DESCRIPTION
## Summary

A new **Spel** tab listing one game per year. 2025 (Flipper) is playable: a full pinball table built in Three.js, designed mobile-first. Years without a game show as "not built yet", so adding future years is a two-line change.

### Physics
Custom 2D simulation rather than a physics engine. A pinball is a ball on a tilted plane, so exact capsule/circle collision with adaptive substepping gives precise control over flipper feel — the thing that makes or breaks pinball — with no 300 KB dependency and no tunnelling at speed.

Flippers impart the **contact point's** velocity rather than a fixed impulse, so tip shots come off faster than base shots, the way a real flipper behaves. Verified: contact at 35% of the flipper vs 95% produces measurably different ball speeds.

### The table
Shooter lane feeding a habitrail around the top dome, three pop bumpers topped with trophies, slingshots, a P-O-K-A-L drop target bank that raises the multiplier when cleared, and a jackpot trophy. The playfield artwork — title, lane guides, target labels, and the roll of honour listing every competitor — is drawn to a canvas at runtime, so the game ships **no image or audio assets**.

### Presentation
Bloom post-processing, PBR materials with environment reflections, a chrome ball casting a real shadow, and synthesized Web Audio sound effects. High score persists in localStorage.

### Controls
| | Mobile | Desktop |
| --- | --- | --- |
| Flippers | Left/right screen halves, true multi-touch | ←/→, A/D, Z/M |
| Plunger | Hold to charge, release to fire | Space |
| Nudge | NUDGA button | N |

Releasing the plunger inside the teal band is a **skill shot**. Four quick nudges trigger TILT and kill the flippers for that ball. Three balls, with a ball save on the first nine seconds.

### Loading
Three.js is dynamically imported only when the game is opened — the site's initial load is unchanged. The table is fully torn down (geometries, materials, textures, renderer, audio context) when the game closes or you leave the tab.

## Bugs found by testing, fixed before shipping
I built a headless simulation harness that runs the physics in Node without a browser. It caught three issues a visual check would have missed:

1. **The shooter lane was narrower than the ball.** Clear width 1.20 vs a 1.24 ball — the ball jammed and every launch died silently.
2. **A weak plunge stranded the ball.** Looping the habitrail costs ~48 u/s of climb; below that the ball fell back into a lane with no route out. The launch floor now always clears it, and the meter became a skill shot instead of a power that can fail.
3. **The playfield artwork was being erased.** A film-grain pass used `putImageData`, which *replaces* pixels rather than compositing, wiping everything beneath it and leaving a near-white table.

Also fixed: a stray `rotateZ` flipped the playfield texture 180°, and the scene was badly over-exposed because `RoomEnvironment` is a bright studio and nearly every material was metallic.

## Test plan
- [x] Node simulation harness: launches across the full power range reach play with no tunnelling and no NaN; 10/10 balls drain with no traps; every scoring element registers hits; the target bank can be cleared; flipper tip-vs-base velocity differs correctly
- [x] Browser tests on mobile (390×844) and desktop (1440×900): game loads, starts, plunger charges and fires, flippers respond to pointer input — **zero console errors**
- [x] Full site regression across all six views, both themes, desktop and mobile — zero console errors
- [x] ESLint passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb)_