### PR TITLE
Give Pages deployments longer than the 10 minute default

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,3 +68,8 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          # Default is 10 minutes. Deployments have sat queued longer than that,
+          # and the action cancels them when it gives up.
+          timeout: 1800000
+          error_count: 20


### PR DESCRIPTION
## Summary

Deploys have been failing since run #60. The build is not the problem — the logs show the deployment sitting in `deployment_queued` for the full ten minutes, then:

```
Current status: deployment_queued
##[error]Timeout reached, aborting!
Canceling Pages deployment...
```

`actions/deploy-pages` waits 10 minutes by default and **cancels the deployment** when it gives up. So a slow Pages queue was throwing away work that hadn't actually failed. The artifact is 656 KB across 24 files, and GitHub reports Pages as operational.

This raises the wait to 30 minutes and tolerates more transient status-API errors.

Deliberately the only change: run #59 succeeded with these exact action versions 40 minutes before the first failure, so the actions themselves are not implicated and bumping them would add risk without evidence.

## Test plan
- [x] Diff is limited to the `timeout` and `error_count` inputs on the deploy step
- [ ] Watching this run: confirms whether the queue drains given more time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb)_