### PR TITLE
Fix mirrored flipper visuals and add nudge shake

### DIFF
--- a/src/games/pinball/index.js
+++ b/src/games/pinball/index.js
@@ -584,6 +584,35 @@ export async function createPinball(container, opts = {}) {
     }
   }
 
+  /* ---- Shake: physical jolt of the 3D table plus a screen shake ---- */
+  const shake = { t: 99, dur: 0, mag: 0, dirX: 0 };
+
+  function startShake(mag, dirX) {
+    shake.t = 0;
+    shake.dur = 0.42;
+    shake.mag = mag;
+    shake.dirX = dirX;
+    // CSS shake on the whole stage (canvas + HUD); restart if mid-animation
+    container.classList.remove('pb-shake');
+    void container.offsetWidth;
+    container.classList.add('pb-shake');
+    if (navigator.vibrate) navigator.vibrate(mag > 1 ? [40, 40, 60] : 25);
+  }
+
+  function updateShake(dt) {
+    if (shake.t >= shake.dur) {
+      tableGroup.position.set(0, 0, 0);
+      tableGroup.rotation.z = 0;
+      return;
+    }
+    shake.t += dt;
+    const damp = Math.max(0, 1 - shake.t / shake.dur) ** 1.6;
+    tableGroup.position.x =
+      (Math.sin(shake.t * 56) * 0.24 + shake.dirX * 0.3) * damp * shake.mag;
+    tableGroup.position.z = Math.sin(shake.t * 47 + 1.7) * 0.16 * damp * shake.mag;
+    tableGroup.rotation.z = Math.sin(shake.t * 50) * 0.008 * damp * shake.mag;
+  }
+
   function doNudge() {
     if (state.phase !== 'play' || state.tilted) return;
     const now = performance.now();
@@ -594,18 +623,21 @@ export async function createPinball(container, opts = {}) {
       state.tilted = true;
       flipL.pressed = false;
       flipR.pressed = false;
+      startShake(2.2, 0);
       toast('TILT — flipprarna är döda', true);
       sfx.drain();
       return;
     }
-    world.nudgeX = (Math.random() - 0.5) * 70;
+    const dir = Math.random() < 0.5 ? -1 : 1;
+    world.nudgeX = dir * 35 + (Math.random() - 0.5) * 20;
     world.nudgeY = 34;
-    ball.vx += (Math.random() - 0.5) * 5;
+    ball.vx += dir * 2.5 + (Math.random() - 0.5) * 3;
     ball.vy += 2.6;
     setTimeout(() => {
       world.nudgeX = 0;
       world.nudgeY = 0;
     }, 90);
+    startShake(1, dir);
     sfx.wall();
     toast('Nudge');
   }
@@ -742,8 +774,15 @@ export async function createPinball(container, opts = {}) {
     refs.ball.visible = ball.live;
 
     // Flippers
-    refs.flippers.left.rotation.y = -flipL.angle;
-    refs.flippers.right.rotation.y = -flipR.angle;
+    // rotation.y = +angle, NOT -angle: the playfield→world mapping (y → −z)
+    // is a reflection, and a positive Y-rotation already sweeps +x toward −z,
+    // which is exactly playfield-counterclockwise. Negating the angle mirrors
+    // the visual flipper against the physics one — it looks like it swings
+    // down while the real (invisible) flipper swings up.
+    refs.flippers.left.rotation.y = flipL.angle;
+    refs.flippers.right.rotation.y = flipR.angle;
+
+    updateShake(dtRaw);
 
     // Plunger pull-back
     if (refs.plunger) {
@@ -817,6 +856,7 @@ export async function createPinball(container, opts = {}) {
     window.removeEventListener('keydown', onKeyDown);
     window.removeEventListener('keyup', onKeyUp);
     clearTimeout(state.lastToast);
+    container.classList.remove('pb-shake');
 
     scene.traverse((o) => {
       if (o.geometry) o.geometry.dispose();

--- a/src/styles/games.css
+++ b/src/styles/games.css
@@ -599,3 +599,24 @@ body.game-open {
   margin-bottom: var(--sp-3);
   filter: drop-shadow(0 4px 16px rgba(242, 193, 78, 0.35));
 }
+
+/* Screen shake on nudge — applied to the whole game mount (canvas + HUD) */
+@keyframes pb-shake {
+  0% { transform: translate(0, 0) rotate(0); }
+  15% { transform: translate(-7px, 3px) rotate(-0.5deg); }
+  30% { transform: translate(6px, -4px) rotate(0.4deg); }
+  45% { transform: translate(-5px, 2px) rotate(-0.3deg); }
+  60% { transform: translate(4px, -2px) rotate(0.2deg); }
+  80% { transform: translate(-2px, 1px) rotate(-0.1deg); }
+  100% { transform: translate(0, 0) rotate(0); }
+}
+
+.pb-shake {
+  animation: pb-shake 0.4s cubic-bezier(0.36, 0.07, 0.19, 0.97);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pb-shake {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## The flipper bug

The rendered flippers were **vertically mirrored against the physics**. The playfield→world mapping (y → −z) is a reflection, and a positive Y-rotation already sweeps +x toward −z — which *is* playfield-counterclockwise — so negating the flipper angle for rendering (`rotation.y = -angle`) flipped the visible swing. The flipper you saw swung **down** while the invisible physics flipper swung **up**: every shot looked like it fired the wrong way, even though the simulation (which is why the physics tests all passed) was behaving correctly.

Fix: `rotation.y = +angle`. Verified with before/after renders — flippers now rest in the classic **V pointing at the drain** and visibly swing **up** when pressed, matching exactly where the ball goes.

## Nudge shake

Nudging now physically registers, three ways:
- a damped positional + rotational jolt on the 3D table itself (in the render loop, direction-biased to match the physics impulse)
- a CSS screen shake on the whole game stage (canvas + HUD), `prefers-reduced-motion` aware
- haptic vibration on phones — short buzz for a nudge, a heavier pattern on TILT

TILT also gets a bigger table shake. The nudge impulse now shares its direction with the visual jolt instead of being fully random.

## Bug found during verification

My scripted edit had appended the shake-class cleanup into `toast()` as well as `destroy()` (two identical anchor lines), so every "Nudge" toast instantly cancelled the screen shake it had just started. Caught because the verification asserted the class was actually present mid-shake — it wasn't — and fixed.

## Test plan
- [x] Node physics harness: all structural checks pass (physics untouched)
- [x] Renders verified: rest pose is the correct V; both tips swing up when pressed
- [x] Browser test: nudge during play applies the shake class, TILT still triggers after 4 rapid nudges, zero console errors
- [x] ESLint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb)_