### PR TITLE
Retrigger deploy: patient job was cancelled while queued for a runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,5 @@ ratingen mer än ett år med tre.
 
 Push till `main` kör [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml)
 som bygger projektet och publicerar till GitHub Pages. Inget manuellt steg behövs.
+
+<!-- Deploy retrigger: 2026-08-06T18:40:05Z -->


### PR DESCRIPTION
The 17:51 run for the patched patient deployer (PR #47) never executed: `build-and-publish` waited 15 minutes without ever being assigned a runner (runner_id 0) and was then cancelled, so `deploy-patient` was skipped. The patched action is still untested.

This is a trivial README stamp to trigger a fresh run.

If the Pages source has been switched back to **GitHub Actions** (Settings → Pages), the patient deployer in this run gets a 45-minute budget to outlast the slow queue. If the source is still on branch mode, the gh-pages publish covers that path and the patient job may fail fast — both paths run independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb)_