### PR TITLE
Retrigger deploy during GitHub's gradual recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,4 @@ Push till `main` kör [`.github/workflows/deploy.yml`](.github/workflows/deploy.
 som bygger projektet och publicerar till GitHub Pages. Inget manuellt steg behövs.
 
 <!-- Deploy retrigger: 2026-08-06T18:40:05Z -->
+<!-- Deploy retrigger: 2026-08-06T19:54:40Z -->


### PR DESCRIPTION
GitHub's 19:43 UTC incident update says Actions capacity is "recovering gradually" — so fresh runs now have real odds of landing. This README stamp fires a new "Deploy to GitHub Pages" run whose `deploy-patient` job (45-minute budget) can outlast whatever queue latency remains. A parallel gh-pages retrigger (2a6c36f) was pushed for the internal-builder path; both race, whichever lands first wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb)_