### PR TITLE
Pinball: Medieval Madness-style ruleset — modes, multiball, combos, wizard mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,20 @@ Att lägga till ett nytt års spel:
 | Avfyrare | Håll för kraft, släpp för att skjuta | Mellanslag |
 | Nudga | Knappen NUDGA | N |
 
-Släpp avfyraren när mätaren står i det turkosa fältet för en **skill shot**.
+Släpp avfyraren när mätaren står i det turkosa fältet för en **skill shot** —
+och skjut vänster orbit inom tre sekunder för en **super skill shot** (15 000).
 Fyra nudgar för snabbt ger TILT och dödar flipprarna för den bollen.
+
+**Regler (à la Medieval Madness)**
+
+| Moment | Så funkar det |
+| --- | --- |
+| **Grenar** | Fäll hela POKAL-banken → skjut vänster orbit för att starta en gren på tid: Gokart '12, Femkamp '13, Pingis '19, Skytte '22 (träffa målen i ordning!), Fiske '24. Klarad gren = 15 000 och en tänd årsbricka. |
+| **FINALEN** | Klara alla fem grenar → wizard mode: 60 sekunder multiball där **allt räknas ×5**. |
+| **Multiball** | Bumperträffar laddar låset — när det lyser låser pokalen bollar. Två låsta bollar startar multiball med jackpot (25 000) i pokalen; orbits tänder om jackpotten. |
+| **Kombo** | Träffar inom 3,5 sekunder kedjar: 1 000 × 2 per steg, upp till ×16. |
+| **Bonus** | Inbanorna höjer bonusmultiplikatorn (upp till ×6) som multiplicerar slutbonusen per boll. |
+| **Extraboll** | Två klarade grenar ger en extra boll. |
 
 ---
 

--- a/src/games/pinball/index.js
+++ b/src/games/pinball/index.js
@@ -90,6 +90,26 @@ class Sfx {
   complete() {
     [0, 70, 140, 210, 320].forEach((d, i) => setTimeout(() => this.tone(392 * 2 ** (i / 6), 0.2, 'square', 0.4), d));
   }
+  orbit() { this.tone(340, 0.14, 'sawtooth', 0.3, 500); }
+  combo(n) { this.tone(440 * 1.25 ** Math.min(n, 6), 0.12, 'square', 0.45, 180); }
+  lock() {
+    this.tone(120, 0.3, 'square', 0.55, -40);
+    setTimeout(() => this.tone(90, 0.35, 'sine', 0.5, -20), 120);
+  }
+  multiball() {
+    [0, 100, 200, 300, 450, 600].forEach((d, i) =>
+      setTimeout(() => this.tone(262 * 2 ** (i / 4), 0.22, i % 2 ? 'square' : 'sawtooth', 0.5), d));
+  }
+  modeStart() {
+    [0, 130, 260].forEach((d, i) => setTimeout(() => this.tone(196 * (i + 2) / 2, 0.24, 'sawtooth', 0.5), d));
+  }
+  modeWin() {
+    [0, 80, 160, 240, 320, 480].forEach((d, i) =>
+      setTimeout(() => this.tone(523 * 2 ** (i / 5), 0.18, 'triangle', 0.5), d));
+  }
+  extraBall() {
+    [0, 120, 240, 360].forEach((d, i) => setTimeout(() => this.tone(660 + i * 110, 0.16, 'triangle', 0.5), d));
+  }
 }
 
 /* ---------------------------------------------------------------------- HUD */
@@ -105,9 +125,16 @@ function buildHud(root) {
         <div class="pb-meta">
           <div class="pb-mult" id="pb-mult">×1</div>
           <div class="pb-balls" id="pb-balls"></div>
+          <div class="pb-substatus" id="pb-substatus"></div>
         </div>
       </div>
       <div class="pb-pokal" id="pb-pokal"></div>
+      <div class="pb-grenar" id="pb-grenar"></div>
+      <div class="pb-mode" id="pb-mode" hidden>
+        <span class="pb-mode-name" id="pb-mode-name"></span>
+        <span class="pb-mode-task" id="pb-mode-task"></span>
+        <span class="pb-mode-time" id="pb-mode-time"></span>
+      </div>
       <div class="pb-toast" id="pb-toast"></div>
     </div>
 
@@ -141,6 +168,12 @@ function buildHud(root) {
     mult: root.querySelector('#pb-mult'),
     balls: root.querySelector('#pb-balls'),
     pokal: root.querySelector('#pb-pokal'),
+    grenar: root.querySelector('#pb-grenar'),
+    mode: root.querySelector('#pb-mode'),
+    modeName: root.querySelector('#pb-mode-name'),
+    modeTask: root.querySelector('#pb-mode-task'),
+    modeTime: root.querySelector('#pb-mode-time'),
+    substatus: root.querySelector('#pb-substatus'),
     toast: root.querySelector('#pb-toast'),
     overlay: root.querySelector('#pb-overlay'),
     title: root.querySelector('#pb-title'),
@@ -216,6 +249,28 @@ export async function createPinball(container, opts = {}) {
   const { group: tableGroup, refs } = buildTable(THREE, mergeGeometries, materials);
   scene.add(tableGroup);
 
+  // Ball mesh pool for multiball, plus parked meshes for locked balls
+  const ballMeshes = [refs.ball];
+  for (let i = 1; i < 3; i++) {
+    const m = refs.ball.clone();
+    m.visible = false;
+    tableGroup.add(m);
+    ballMeshes.push(m);
+  }
+  const lockMeshes = L.lockSlots.map((s) => {
+    const m = refs.ball.clone();
+    m.position.set(s.x, L.ballRadius + 0.04, -s.y);
+    m.visible = false;
+    tableGroup.add(m);
+    return m;
+  });
+
+  // Bumper ring materials are cloned so each bumper can show its own
+  // charged state on the way to lighting the lock.
+  refs.bumpers.forEach((b) => {
+    b.ring.material = b.ring.material.clone();
+  });
+
   /* ---- Lights ---- */
   scene.add(new THREE.AmbientLight(0x9fb0ff, 0.16));
 
@@ -250,23 +305,59 @@ export async function createPinball(container, opts = {}) {
 
   /* ---- Physics ---- */
   const world = new World({ gravity: 27, damping: 0.2, maxSpeed: 64 });
-  const ball = new Ball(L.ballRadius);
+
+  /**
+   * Grenar — the mode ladder, named after the group's real competitions.
+   * Complete P-O-K-A-L to light mode start at the LEFT ORBIT. Complete all
+   * five and the left orbit starts FINALEN, the wizard mode.
+   */
+  const MODES = [
+    { id: 'gokart', year: 2012, name: 'GOKART', hint: 'Kör 3 varv i orbit', goal: 3, time: 35 },
+    { id: 'femkamp', year: 2013, name: 'FEMKAMP', hint: 'Träffa alla 5 olika skott', goal: 5, time: 60 },
+    { id: 'pingis', year: 2019, name: 'PINGIS', hint: '12 bumperträffar', goal: 12, time: 35 },
+    { id: 'skytte', year: 2022, name: 'SKYTTE', hint: 'Fäll P→O→K→A→L i ordning', goal: 5, time: 45 },
+    { id: 'fiske', year: 2024, name: 'FISKE', hint: '3 napp på pokalen', goal: 3, time: 35 }
+  ];
 
   const state = {
     phase: 'idle', // idle | launch | play | between | over
     score: 0,
     ballNo: 1,
     mult: 1,
+    balls: [], // live Ball objects (multiball-capable)
     pokal: [false, false, false, false, false],
     banksDone: 0,
     ballSaveUntil: 0,
-    stuckFor: 0,
-    laneFor: 0,
     nudges: [],
     tilted: false,
     power: 0,
     charging: false,
-    lastToast: 0
+    lastToast: 0,
+
+    // Locks & multiball
+    bumperHits: [0, 0, 0],
+    bumperLit: [false, false, false],
+    lockLit: false,
+    locked: 0,
+    multiball: false,
+    jackpotLit: false,
+    mbSaveUntil: 0,
+
+    // Grenar (modes)
+    modeDone: new Set(),
+    mode: null, // { def, progress, timeLeft, seen:Set, wizard }
+    modeStartLit: false,
+    finalenDone: 0,
+
+    // Combos, bonus, extra balls
+    combo: { n: 0, t: 0 },
+    bonusX: 1,
+    inlanes: { left: false, right: false },
+    perBall: { bumps: 0, targets: 0, orbits: 0 },
+    extraBalls: 0,
+    extraBallGiven: false,
+    superUntil: 0,
+    sensorLast: {}
   };
 
   let high = 0;
@@ -281,9 +372,14 @@ export async function createPinball(container, opts = {}) {
   const fmt = (n) => n.toLocaleString('sv-SE');
 
   function renderBalls() {
-    hud.balls.innerHTML = Array.from({ length: BALLS_PER_GAME }, (_, i) =>
-      `<span class="pb-ball-dot ${i < BALLS_PER_GAME - state.ballNo + 1 ? 'on' : ''}"></span>`
-    ).join('');
+    const left = BALLS_PER_GAME - state.ballNo + 1;
+    hud.balls.innerHTML =
+      Array.from({ length: BALLS_PER_GAME }, (_, i) =>
+        `<span class="pb-ball-dot ${i < left ? 'on' : ''}"></span>`
+      ).join('') +
+      Array.from({ length: state.extraBalls }, () =>
+        '<span class="pb-ball-dot on extra"></span>'
+      ).join('');
   }
 
   function renderPokal() {
@@ -292,8 +388,38 @@ export async function createPinball(container, opts = {}) {
       .join('');
   }
 
+  function renderGrenar() {
+    const chips = MODES.map(
+      (m) =>
+        `<span class="pb-gren ${state.modeDone.has(m.id) ? 'won' : ''} ${
+          state.mode && state.mode.def.id === m.id ? 'active' : ''
+        }">'${String(m.year).slice(2)}</span>`
+    );
+    chips.push(
+      `<span class="pb-gren crown ${state.finalenDone ? 'won' : ''} ${
+        state.mode && state.mode.def.id === 'finalen' ? 'active' : ''
+      }">👑</span>`
+    );
+    hud.grenar.innerHTML = chips.join('');
+  }
+
+  function updateStatus() {
+    if (state.mode && state.mode.wizard) {
+      hud.substatus.textContent = 'ALLT ×5';
+    } else if (state.multiball) {
+      hud.substatus.textContent = state.jackpotLit ? 'JACKPOT TÄND' : 'ORBIT LADDAR JACKPOT';
+    } else {
+      const locks = '●'.repeat(state.locked) + '○'.repeat(Math.max(0, 2 - state.locked));
+      const bits = [`LÅS ${locks}`];
+      if (state.bonusX > 1) bits.push(`BONUS ×${state.bonusX}`);
+      if (state.modeStartLit) bits.push('GREN: V. ORBIT');
+      hud.substatus.textContent = bits.join(' · ');
+    }
+  }
+
   function addScore(n) {
-    state.score += Math.round(n * state.mult);
+    const wiz = state.mode && state.mode.wizard ? 5 : 1;
+    state.score += Math.round(n * state.mult * wiz);
     hud.score.textContent = fmt(state.score);
   }
 
@@ -321,14 +447,70 @@ export async function createPinball(container, opts = {}) {
   // buildColliders has returned.
   let colliderRefs = null;
 
+  /* ---- Combos: chained orbit/jackpot shots inside a rolling window ---- */
+  function comboShot() {
+    const now = performance.now();
+    if (now - state.combo.t < 3500) {
+      state.combo.n++;
+      const pts = 1000 * 2 ** Math.min(state.combo.n - 1, 4);
+      addScore(pts);
+      sfx.combo(state.combo.n);
+      toast(`KOMBO ×${state.combo.n} +${fmt(pts)}`, state.combo.n >= 3);
+    } else {
+      state.combo.n = 1;
+    }
+    state.combo.t = now;
+  }
+
+  /* ---- Mode progress from any scoring event ---- */
+  function modeEvent(kind) {
+    const m = state.mode;
+    if (!m || m.wizard) return;
+    const { id } = m.def;
+    if (
+      (id === 'gokart' && (kind === 'leftOrbit' || kind === 'rightOrbit')) ||
+      (id === 'pingis' && kind === 'bumper') ||
+      (id === 'fiske' && kind === 'jackpot')
+    ) {
+      m.progress++;
+    } else if (id === 'femkamp') {
+      const bucket = kind === 'leftOrbit' || kind === 'rightOrbit' ? kind : kind;
+      if (!m.seen.has(bucket)) {
+        m.seen.add(bucket);
+        m.progress = m.seen.size;
+        toast(`FEMKAMP ${m.progress}/5`);
+      }
+    } else {
+      return;
+    }
+    if (m.progress >= m.def.goal) completeMode();
+  }
+
   const hooks = {
     onBumper(i, v) {
       if (v < 1) return;
       const b = refs.bumpers[i];
       addScore(b.isTrophy ? 400 : 120);
+      state.perBall.bumps++;
       sfx.bumper();
       flash(b.trophy, b.light, b.isTrophy ? 6 : 4.2, b.base);
-      if (b.isTrophy) toast('Pokalen +400');
+
+      // Charge the bumpers toward lighting the lock
+      if (!state.multiball && state.locked < 2 && !(state.mode && state.mode.wizard)) {
+        state.bumperHits[i]++;
+        if (state.bumperHits[i] >= 4 && !state.bumperLit[i]) {
+          state.bumperLit[i] = true;
+          refs.bumpers[i].ring.material.emissiveIntensity = 2.6;
+          toast('Bumper laddad!');
+        }
+        if (state.bumperLit.every(Boolean) && !state.lockLit) {
+          state.lockLit = true;
+          sfx.modeStart();
+          toast('LÅS TÄNT — SKJUT POKALEN!', true);
+          updateStatus();
+        }
+      }
+      modeEvent('bumper');
     },
     onSling(side, v) {
       if (v < 1) return;
@@ -341,13 +523,38 @@ export async function createPinball(container, opts = {}) {
       }
     },
     onTarget(i, v) {
-      if (v < 0.6 || state.pokal[i]) return;
+      if (v < 0.6) return;
+
+      // SKYTTE mode: the bank must fall in exact P→O→K→A→L order
+      if (state.mode && state.mode.def.id === 'skytte') {
+        if (state.pokal[i]) return;
+        if (i === state.mode.progress) {
+          state.pokal[i] = true;
+          colliderRefs.targets[i].enabled = false;
+          refs.targets[i].down = true;
+          state.mode.progress++;
+          state.perBall.targets++;
+          addScore(1200);
+          sfx.target();
+          renderPokal();
+          if (state.mode.progress >= 5) completeMode();
+          else toast(`${L.targets[i].letter} ✓ — nästa: ${L.targets[state.mode.progress].letter}`);
+        } else {
+          toast(`Fel ordning — sikta på ${L.targets[state.mode.progress].letter}`);
+          sfx.wall();
+        }
+        return;
+      }
+
+      if (state.pokal[i]) return;
       state.pokal[i] = true;
       colliderRefs.targets[i].enabled = false;
       refs.targets[i].down = true;
       addScore(600);
+      state.perBall.targets++;
       sfx.target();
       renderPokal();
+      modeEvent('target');
 
       if (state.pokal.every(Boolean)) {
         state.banksDone++;
@@ -355,19 +562,106 @@ export async function createPinball(container, opts = {}) {
         hud.mult.textContent = `×${state.mult}`;
         addScore(6000);
         sfx.complete();
-        toast(`P-O-K-A-L KOMPLETT — ×${state.mult}`, true);
-        setTimeout(resetBank, 1700);
+        if (!state.mode) {
+          state.modeStartLit = true;
+          const allDone = MODES.every((m) => state.modeDone.has(m.id));
+          toast(allDone ? 'FINALEN TÄND — VÄNSTER ORBIT!' : `P-O-K-A-L — GREN TÄND I VÄNSTER ORBIT`, true);
+        } else {
+          toast(`P-O-K-A-L KOMPLETT — ×${state.mult}`, true);
+        }
+        updateStatus();
+        setTimeout(() => {
+          if (!(state.mode && state.mode.def.id === 'skytte')) resetBank();
+        }, 1700);
       } else {
         toast(`${L.targets[i].letter} träffad`);
       }
     },
-    onJackpot(v) {
+    onJackpot(v, b) {
       if (v < 1) return;
-      const lit = state.banksDone > 0;
-      addScore(lit ? 25000 : 2500);
-      sfx.jackpot();
       flash(refs.jackpot.trophy, refs.jackpot.light, 5, 0.85);
-      toast(lit ? 'JACKPOT!' : 'Pokalen träffad', lit);
+
+      // Multiball jackpot
+      if (state.multiball && state.jackpotLit) {
+        state.jackpotLit = false;
+        addScore(25000);
+        sfx.jackpot();
+        toast('JACKPOT +25 000!', true);
+        updateStatus();
+        return;
+      }
+
+      // A running mode owns the trophy: FISKE needs these hits, so the
+      // lock waits until the mode is over.
+      if (state.mode && !state.mode.wizard) {
+        addScore(2500);
+        sfx.jackpot();
+        comboShot();
+        modeEvent('jackpot');
+        return;
+      }
+
+      // Lock a ball toward multiball
+      if (state.lockLit && !state.multiball && b) {
+        lockBall(b);
+        return;
+      }
+
+      addScore(2500);
+      sfx.jackpot();
+      comboShot();
+      modeEvent('jackpot');
+    },
+    onSensor(id, _v, _b) {
+      const now = performance.now();
+      if (now - (state.sensorLast[id] || 0) < 700) return;
+      state.sensorLast[id] = now;
+      if (state.phase !== 'play') return;
+
+      if (id === 'inlaneLeft' || id === 'inlaneRight') {
+        const side = id === 'inlaneLeft' ? 'left' : 'right';
+        if (!state.inlanes[side]) {
+          state.inlanes[side] = true;
+          sfx.target();
+          if (state.inlanes.left && state.inlanes.right) {
+            state.inlanes.left = false;
+            state.inlanes.right = false;
+            state.bonusX = Math.min(6, state.bonusX + 1);
+            toast(`BONUS ×${state.bonusX}`, state.bonusX >= 3);
+            updateStatus();
+          }
+        }
+        return;
+      }
+
+      // Orbits
+      addScore(1500);
+      state.perBall.orbits++;
+      sfx.orbit();
+      comboShot();
+      modeEvent(id);
+
+      if (state.multiball && !state.jackpotLit) {
+        state.jackpotLit = true;
+        toast('JACKPOT TÄND — SKJUT POKALEN!', true);
+        updateStatus();
+        return;
+      }
+
+      // Super skill shot: straight around into the left orbit off the plunge
+      if (id === 'leftOrbit' && now < state.superUntil) {
+        state.superUntil = 0;
+        addScore(15000);
+        sfx.modeWin();
+        toast('SUPER SKILL SHOT +15 000!', true);
+        return;
+      }
+
+      // Mode start
+      if (id === 'leftOrbit' && state.modeStartLit && !state.mode && !state.multiball) {
+        state.modeStartLit = false;
+        startNextMode();
+      }
     },
     onWall(v) {
       if (v > 9) sfx.wall();
@@ -390,10 +684,174 @@ export async function createPinball(container, opts = {}) {
     renderPokal();
   }
 
+  /* ======================= Grenar (modes) ======================= */
+
+  function startNextMode() {
+    const next = MODES.find((m) => !state.modeDone.has(m.id));
+    if (!next) {
+      startFinalen();
+      return;
+    }
+    state.mode = { def: next, progress: 0, timeLeft: next.time, seen: new Set(), wizard: false };
+    if (next.id === 'skytte') resetBank();
+    sfx.modeStart();
+    toast(`${next.name} ${next.year} — ${next.hint}!`, true);
+    warm.color.set(0x7c8cf8);
+    hud.mode.hidden = false;
+    renderGrenar();
+    updateStatus();
+  }
+
+  function completeMode() {
+    const m = state.mode;
+    if (!m) return;
+    state.modeDone.add(m.def.id);
+    addScore(15000);
+    sfx.modeWin();
+    toast(`${m.def.name} KLAR! +15 000`, true);
+    endMode();
+
+    if (state.modeDone.size >= 2 && !state.extraBallGiven) {
+      state.extraBallGiven = true;
+      state.extraBalls++;
+      renderBalls();
+      setTimeout(() => {
+        sfx.extraBall();
+        toast('EXTRA BOLL!', true);
+      }, 1500);
+    }
+  }
+
+  function failMode() {
+    const m = state.mode;
+    if (!m) return;
+    if (m.wizard) {
+      // Finalen simply ends — it cannot be failed
+      state.finalenDone++;
+      state.modeDone.clear();
+      sfx.modeWin();
+      toast('FINALEN ÖVER — grenarna är nollställda!', true);
+      endMode();
+      if (state.balls.length > 1) state.mbSaveUntil = 0;
+      return;
+    }
+    sfx.drain();
+    toast(`Tiden ute — ${m.def.name} missad`, true);
+    endMode();
+  }
+
+  function endMode() {
+    const wasSkytte = state.mode && state.mode.def.id === 'skytte';
+    state.mode = null;
+    hud.mode.hidden = true;
+    warm.color.set(0xf2c14e);
+    if (wasSkytte) resetBank();
+    renderGrenar();
+    updateStatus();
+  }
+
+  function startFinalen() {
+    state.mode = {
+      def: { id: 'finalen', name: 'FINALEN', hint: 'Allt räknas ×5', goal: 0, time: 60 },
+      progress: 0,
+      timeLeft: 60,
+      seen: new Set(),
+      wizard: true
+    };
+    state.multiball = true;
+    state.jackpotLit = true;
+    state.mbSaveUntil = performance.now() + 60000;
+    sfx.multiball();
+    toast('FINALEN — ALLA BOLLAR, ALLT ×5!', true);
+    warm.color.set(0xffe08a);
+    warm.intensity = 1.6;
+    bloom.strength = 0.8;
+    hud.mode.hidden = false;
+    renderGrenar();
+    updateStatus();
+    serveBall(300);
+    serveBall(1100);
+  }
+
+  /* ==================== Locks & multiball ==================== */
+
+  function lockBall(b) {
+    b.live = false;
+    const idx = state.balls.indexOf(b);
+    if (idx >= 0) state.balls.splice(idx, 1);
+    lockMeshes[state.locked].visible = true;
+    state.locked++;
+    state.lockLit = false;
+    state.bumperHits = [0, 0, 0];
+    state.bumperLit = [false, false, false];
+    refs.bumpers.forEach((bm) => {
+      bm.ring.material.emissiveIntensity = 0.95;
+    });
+    sfx.lock();
+    updateStatus();
+
+    if (state.locked >= 2) {
+      toast('BOLL 2 LÅST…', true);
+      setTimeout(startMultiball, 900);
+    } else {
+      toast(`BOLL LÅST ${state.locked}/2`, true);
+      serveBall(700);
+    }
+  }
+
+  function startMultiball() {
+    state.multiball = true;
+    state.jackpotLit = true;
+    state.mbSaveUntil = performance.now() + 12000;
+    sfx.multiball();
+    startShake(1.4, 0);
+    toast('MULTIBALL!', true);
+    bloom.strength = 0.72;
+
+    // Release the locked balls into play
+    L.lockSlots.forEach((slot, i) => {
+      lockMeshes[i].visible = false;
+      const nb = new Ball(L.ballRadius);
+      nb.place(slot.x, slot.y, 7 + i * 2, -5);
+      nb.live = true;
+      state.balls.push(nb);
+    });
+    state.locked = 0;
+    updateStatus();
+  }
+
+  function endMultiball() {
+    state.multiball = false;
+    state.jackpotLit = false;
+    bloom.strength = 0.5;
+    warm.intensity = 0.8;
+    toast('Multiball slut');
+    updateStatus();
+  }
+
+  /**
+   * Puts a fresh ball in the shooter lane and auto-plunges it shortly after —
+   * used for lock replacements, multiball serves and Finalen.
+   */
+  function serveBall(delay = 600) {
+    setTimeout(() => {
+      if (state.phase !== 'play') return;
+      const nb = new Ball(L.ballRadius);
+      nb.place(L.laneBallX, L.laneBottomY + L.laneWallR + L.ballRadius + 0.06, 0, 0);
+      nb.live = true;
+      state.balls.push(nb);
+      setTimeout(() => {
+        if (nb.live && nb.x > L.laneX) nb.vy = 52 + Math.random() * 8;
+      }, 500);
+    }, delay);
+  }
+
   /* ---- Ball lifecycle ---- */
   function placeInLane() {
-    ball.place(L.laneBallX, L.laneBottomY + L.laneWallR + L.ballRadius + 0.06, 0, 0);
-    ball.live = true;
+    const nb = new Ball(L.ballRadius);
+    nb.place(L.laneBallX, L.laneBottomY + L.laneWallR + L.ballRadius + 0.06, 0, 0);
+    nb.live = true;
+    state.balls = [nb];
     state.phase = 'launch';
     state.power = 0;
     state.charging = false;
@@ -406,10 +864,13 @@ export async function createPinball(container, opts = {}) {
     // Looping the habitrail costs ~48 u/s of climb, so every launch clears it.
     // The meter is a timing skill shot instead of a power that can strand you.
     const p = clamp(state.power, 0, 1);
-    ball.vy = 51 + p * 11;
-    ball.vx = 0;
+    const b = state.balls[0];
+    if (!b) return;
+    b.vy = 51 + p * 11;
+    b.vx = 0;
     state.phase = 'play';
     state.ballSaveUntil = performance.now() + BALL_SAVE_MS;
+    state.superUntil = performance.now() + 3000;
     hud.plunger.hidden = true;
     hud.controls.hidden = false;
     sfx.launch();
@@ -417,15 +878,33 @@ export async function createPinball(container, opts = {}) {
     if (p >= SKILL_ZONE[0] && p <= SKILL_ZONE[1]) {
       addScore(5000);
       sfx.complete();
-      toast('SKILL SHOT +5000', true);
+      toast('SKILL SHOT +5000 — orbit för SUPER!', true);
     } else {
       toast('Bollen är i spel');
     }
   }
 
-  function drainBall() {
-    if (state.phase !== 'play') return;
+  /**
+   * One ball left play. In multiball the others carry on; the last ball
+   * triggers save / extra ball / end-of-ball bonus.
+   */
+  function drainOne(b) {
+    const idx = state.balls.indexOf(b);
+    if (idx >= 0) state.balls.splice(idx, 1);
+    b.live = false;
 
+    if (state.balls.length >= 1) {
+      // Multiball continues — respawn during the grace window
+      if (performance.now() < state.mbSaveUntil) {
+        toast('Boll räddad!');
+        serveBall(400);
+      } else if (state.balls.length === 1 && state.multiball && !(state.mode && state.mode.wizard)) {
+        endMultiball();
+      }
+      return;
+    }
+
+    // Last ball gone
     if (performance.now() < state.ballSaveUntil) {
       sfx.launch();
       toast('BOLLRÄDDNING', true);
@@ -438,21 +917,55 @@ export async function createPinball(container, opts = {}) {
     }
 
     sfx.drain();
-    ball.live = false;
     state.phase = 'between';
+    if (state.multiball) endMultiball();
+    if (state.mode) {
+      if (state.mode.wizard) failMode();
+      else {
+        toast(`${state.mode.def.name} avbruten`);
+        endMode();
+      }
+    }
+
+    // End-of-ball bonus
+    const pb = state.perBall;
+    const bonus = (pb.bumps * 50 + pb.targets * 300 + pb.orbits * 500) * state.bonusX;
+    if (bonus > 0) {
+      setTimeout(() => {
+        state.score += bonus;
+        hud.score.textContent = fmt(state.score);
+        sfx.complete();
+        toast(`BONUS +${fmt(bonus)}${state.bonusX > 1 ? ` (×${state.bonusX})` : ''}`, true);
+      }, 700);
+    }
+    state.perBall = { bumps: 0, targets: 0, orbits: 0 };
+    state.bonusX = 1;
+    state.inlanes = { left: false, right: false };
+    state.combo = { n: 0, t: 0 };
+
+    if (state.extraBalls > 0) {
+      state.extraBalls--;
+      renderBalls();
+      setTimeout(() => {
+        sfx.extraBall();
+        toast('EXTRA BOLL — samma boll igen!', true);
+        if (state.phase === 'between') placeInLane();
+      }, 1900);
+      return;
+    }
 
     if (state.ballNo >= BALLS_PER_GAME) {
-      setTimeout(gameOver, 900);
+      setTimeout(gameOver, 2100);
       return;
     }
     state.ballNo++;
     state.mult = 1;
     hud.mult.textContent = '×1';
     renderBalls();
-    toast(`Boll ${state.ballNo} av ${BALLS_PER_GAME}`, true);
     setTimeout(() => {
+      toast(`Boll ${state.ballNo} av ${BALLS_PER_GAME}`, true);
       if (state.phase === 'between') placeInLane();
-    }, 1100);
+    }, 1900);
   }
 
   function gameOver() {
@@ -487,12 +1000,40 @@ export async function createPinball(container, opts = {}) {
     state.banksDone = 0;
     state.tilted = false;
     state.nudges = [];
+    state.bumperHits = [0, 0, 0];
+    state.bumperLit = [false, false, false];
+    state.lockLit = false;
+    state.locked = 0;
+    state.multiball = false;
+    state.jackpotLit = false;
+    state.mbSaveUntil = 0;
+    state.modeDone = new Set();
+    state.mode = null;
+    state.modeStartLit = false;
+    state.finalenDone = 0;
+    state.combo = { n: 0, t: 0 };
+    state.bonusX = 1;
+    state.inlanes = { left: false, right: false };
+    state.perBall = { bumps: 0, targets: 0, orbits: 0 };
+    state.extraBalls = 0;
+    state.extraBallGiven = false;
+    state.superUntil = 0;
+    lockMeshes.forEach((m) => (m.visible = false));
+    refs.bumpers.forEach((bm) => {
+      bm.ring.material.emissiveIntensity = 0.95;
+    });
+    bloom.strength = 0.5;
+    warm.color.set(0xf2c14e);
+    warm.intensity = 0.8;
+    hud.mode.hidden = true;
     hud.score.textContent = '0';
     hud.mult.textContent = '×1';
     hud.scoreline.hidden = true;
     hud.overlay.classList.remove('show');
     resetBank();
     renderBalls();
+    renderGrenar();
+    updateStatus();
     placeInLane();
   }
 
@@ -631,8 +1172,10 @@ export async function createPinball(container, opts = {}) {
     const dir = Math.random() < 0.5 ? -1 : 1;
     world.nudgeX = dir * 35 + (Math.random() - 0.5) * 20;
     world.nudgeY = 34;
-    ball.vx += dir * 2.5 + (Math.random() - 0.5) * 3;
-    ball.vy += 2.6;
+    state.balls.forEach((b) => {
+      b.vx += dir * 2.5 + (Math.random() - 0.5) * 3;
+      b.vy += 2.6;
+    });
     setTimeout(() => {
       world.nudgeX = 0;
       world.nudgeY = 0;
@@ -732,46 +1275,80 @@ export async function createPinball(container, opts = {}) {
     acc += dtRaw;
     let guard = 0;
     while (acc >= FIXED && guard++ < 8) {
-      world.step(ball, FIXED);
+      world.step(state.balls, FIXED);
       acc -= FIXED;
 
-      if (state.phase === 'play' && ball.live) {
-        if (ball.y < -1.2 || ball.y > 48 || Math.abs(ball.x) > 13) drainBall();
+      if (state.phase === 'play') {
+        for (let bi = state.balls.length - 1; bi >= 0; bi--) {
+          const b = state.balls[bi];
+          if (!b.live) continue;
 
-        // A ball loitering in the shooter lane can never get out on its own
-        if (ball.x > L.laneX && ball.y < L.domeY && ball.speed < 4) {
-          state.laneFor += FIXED;
-          if (state.laneFor > 1.4) {
-            ball.vy = 52;
-            ball.vx = 0;
-            state.laneFor = 0;
-            sfx.launch();
+          if (b.y < -1.2 || b.y > 48 || Math.abs(b.x) > 13) {
+            drainOne(b);
+            continue;
           }
-        } else {
-          state.laneFor = 0;
+
+          // A ball loitering in the shooter lane can never get out on its own
+          if (b.x > L.laneX && b.y < L.domeY && b.speed < 4) {
+            b.laneFor = (b.laneFor || 0) + FIXED;
+            if (b.laneFor > 1.4) {
+              b.vy = 52;
+              b.vx = 0;
+              b.laneFor = 0;
+              sfx.launch();
+            }
+          } else {
+            b.laneFor = 0;
+          }
+
+          // Rescue a ball wedged somewhere with no energy
+          if (b.speed < 0.9) {
+            b.stuckFor = (b.stuckFor || 0) + FIXED;
+            if (b.stuckFor > 3.4) {
+              b.vx += (Math.random() - 0.5) * 10;
+              b.vy += 7;
+              b.stuckFor = 0;
+            }
+          } else {
+            b.stuckFor = 0;
+          }
         }
 
-        // Rescue a ball wedged somewhere with no energy
-        if (ball.speed < 0.9) {
-          state.stuckFor += FIXED;
-          if (state.stuckFor > 3.4) {
-            ball.vx += (Math.random() - 0.5) * 10;
-            ball.vy += 7;
-            state.stuckFor = 0;
-          }
-        } else {
-          state.stuckFor = 0;
+        // Mode clock
+        if (state.mode) {
+          state.mode.timeLeft -= FIXED;
+          if (state.mode.timeLeft <= 0) failMode();
         }
       }
     }
 
-    // Ball transform + rolling spin
-    refs.ball.position.set(ball.x, L.ballRadius + 0.04, -ball.y);
-    if (ball.speed > 0.01) {
-      const axis = new THREE.Vector3(-ball.vy, 0, -ball.vx).normalize();
-      refs.ball.rotateOnWorldAxis(axis, (ball.speed * dtRaw) / L.ballRadius);
+    // Mode HUD
+    if (state.mode) {
+      const m = state.mode;
+      hud.modeName.textContent = m.def.name;
+      hud.modeTask.textContent = m.wizard
+        ? m.def.hint
+        : `${m.progress}/${m.def.goal} — ${m.def.hint}`;
+      const secs = Math.max(0, Math.ceil(m.timeLeft));
+      hud.modeTime.textContent = `0:${String(secs).padStart(2, '0')}`;
+      hud.modeTime.classList.toggle('urgent', secs <= 10);
     }
-    refs.ball.visible = ball.live;
+
+    // Ball transforms + rolling spin (mesh pool)
+    for (let i = 0; i < ballMeshes.length; i++) {
+      const mesh = ballMeshes[i];
+      const b = state.balls[i];
+      if (b && b.live) {
+        mesh.visible = true;
+        mesh.position.set(b.x, L.ballRadius + 0.04, -b.y);
+        if (b.speed > 0.01) {
+          const axis = new THREE.Vector3(-b.vy, 0, -b.vx).normalize();
+          mesh.rotateOnWorldAxis(axis, (b.speed * dtRaw) / L.ballRadius);
+        }
+      } else {
+        mesh.visible = false;
+      }
+    }
 
     // Flippers
     // rotation.y = +angle, NOT -angle: the playfield→world mapping (y → −z)
@@ -820,7 +1397,10 @@ export async function createPinball(container, opts = {}) {
     }
 
     // Gentle parallax toward the action
-    target.x += (ball.x * 0.1 - target.x) * Math.min(1, dtRaw * 2);
+    const lead = state.balls[0];
+    if (lead) {
+      target.x += (lead.x * 0.1 - target.x) * Math.min(1, dtRaw * 2);
+    }
     camera.lookAt(target);
 
     composer.render();
@@ -841,7 +1421,39 @@ export async function createPinball(container, opts = {}) {
 
   renderBalls();
   renderPokal();
+  renderGrenar();
+  updateStatus();
   hud.overlay.classList.add('show');
+
+  // Deterministic hooks for automated tests (and curious friends)
+  window.__pbFlipper = {
+    state,
+    startGame,
+    startNextMode,
+    startMultiball,
+    startFinalen,
+    completeBank() {
+      L.targets.forEach((t, i) => hooks.onTarget(i, 2));
+    },
+    lightLock() {
+      state.bumperLit = [true, true, true];
+      state.lockLit = true;
+      updateStatus();
+    },
+    hitJackpot() {
+      hooks.onJackpot(3, state.balls[0]);
+    },
+    hitSensor(id) {
+      state.sensorLast[id] = 0;
+      hooks.onSensor(id, 3, state.balls[0]);
+    },
+    hitBumper(i) {
+      hooks.onBumper(i, 3);
+    },
+    hitTarget(i) {
+      hooks.onTarget(i, 3);
+    }
+  };
 
   /* ---- Teardown ---- */
   function destroy() {
@@ -857,6 +1469,7 @@ export async function createPinball(container, opts = {}) {
     window.removeEventListener('keyup', onKeyUp);
     clearTimeout(state.lastToast);
     container.classList.remove('pb-shake');
+    delete window.__pbFlipper;
 
     scene.traverse((o) => {
       if (o.geometry) o.geometry.dispose();

--- a/src/games/pinball/physics.js
+++ b/src/games/pinball/physics.js
@@ -47,6 +47,9 @@ export function segment(ax, ay, bx, by, opts = {}) {
     restitution: opts.restitution ?? 0.42,
     friction: opts.friction ?? 0.04,
     kick: opts.kick ?? 0,
+    // A sensor detects the ball passing through without touching it —
+    // used for orbit shots, inlane rollovers and other scoring switches.
+    sensor: opts.sensor ?? false,
     id: opts.id || null,
     onHit: opts.onHit || null,
     enabled: true
@@ -62,6 +65,7 @@ export function circle(cx, cy, radius, opts = {}) {
     restitution: opts.restitution ?? 0.5,
     friction: opts.friction ?? 0.02,
     kick: opts.kick ?? 0,
+    sensor: opts.sensor ?? false,
     id: opts.id || null,
     onHit: opts.onHit || null,
     enabled: true
@@ -257,18 +261,76 @@ export class World {
   }
 
   /**
-   * Advances the simulation. Splits dt into substeps sized so the ball can
-   * never move more than a fraction of its radius per step — without this a
-   * hard shot passes straight through a wall.
+   * Advances the simulation for one or more balls (multiball). Splits dt into
+   * substeps sized so the fastest ball can never move more than a fraction of
+   * its radius per step — without this a hard shot passes straight through a
+   * wall.
    */
-  step(ball, dt) {
-    const speed = Math.max(ball.speed, 1);
-    const steps = clamp(Math.ceil((speed * dt) / (ball.radius * 0.35)), 1, 24);
+  step(balls, dt) {
+    const list = Array.isArray(balls) ? balls : [balls];
+    let top = 1;
+    let radius = 0.6;
+    for (const b of list) {
+      if (b.live && b.speed > top) top = b.speed;
+      ({ radius } = b);
+    }
+    const steps = clamp(Math.ceil((top * dt) / (radius * 0.35)), 1, 24);
     const sdt = dt / steps;
 
     for (let i = 0; i < steps; i++) {
       this.flippers.forEach((f) => f.update(sdt));
-      if (ball.live) this.integrate(ball, sdt);
+      for (const b of list) {
+        if (b.live) this.integrate(b, sdt);
+      }
+      if (list.length > 1) this.collideBalls(list);
+    }
+  }
+
+  /**
+   * Elastic equal-mass collision between live balls — what makes multiball
+   * feel like metal instead of ghosts passing through each other.
+   */
+  collideBalls(list) {
+    for (let i = 0; i < list.length; i++) {
+      const a = list[i];
+      if (!a.live) continue;
+      for (let j = i + 1; j < list.length; j++) {
+        const b = list[j];
+        if (!b.live) continue;
+
+        let dx = b.x - a.x;
+        let dy = b.y - a.y;
+        let dist = len(dx, dy);
+        const minDist = a.radius + b.radius;
+        if (dist >= minDist) continue;
+
+        if (dist < 1e-6) {
+          dx = 1;
+          dy = 0;
+          dist = 1;
+        }
+        const nx = dx / dist;
+        const ny = dy / dist;
+
+        // Separate evenly
+        const push = (minDist - dist) / 2;
+        a.x -= nx * push;
+        a.y -= ny * push;
+        b.x += nx * push;
+        b.y += ny * push;
+
+        // Exchange the normal components (equal mass), slightly inelastic
+        const van = a.vx * nx + a.vy * ny;
+        const vbn = b.vx * nx + b.vy * ny;
+        if (van - vbn > 0) {
+          const e = 0.92;
+          const impulse = ((van - vbn) * (1 + e)) / 2;
+          a.vx -= nx * impulse;
+          a.vy -= ny * impulse;
+          b.vx += nx * impulse;
+          b.vy += ny * impulse;
+        }
+      }
     }
   }
 
@@ -329,6 +391,12 @@ export class World {
     let dist = len(dx, dy);
     const minDist = ball.radius + c.radius;
     if (dist >= minDist) return false;
+
+    // Sensors only observe — no bounce, no depenetration
+    if (c.sensor) {
+      if (c.onHit) c.onHit(ball.speed, ball);
+      return false;
+    }
 
     if (dist < 1e-6) {
       dx = 0;

--- a/src/games/pinball/table.js
+++ b/src/games/pinball/table.js
@@ -73,9 +73,28 @@ L.posts = [
   { x: L.centerX + 5.2, y: 22.6, r: 0.3 }
 ];
 
+// Scoring switches: invisible sensors the ball rolls through.
+// Orbits are the open lanes either side of the target bank; inlanes are the
+// return channels that feed the flippers.
+L.sensors = {
+  leftOrbit: [-8.6, 18, -6.6, 18],
+  rightOrbit: [4.2, 18, 6.2, 18],
+  inlaneLeft: [-5.55, 6.6, -4.35, 7.1],
+  inlaneRight: [mirrorXRaw(-5.55), 6.6, mirrorXRaw(-4.35), 7.1]
+};
+
+// Where locked balls are parked while waiting for multiball
+L.lockSlots = [
+  { x: -7.6, y: 27.4 },
+  { x: -6.7, y: 29.6 }
+];
+
 /* ------------------------------------------------------------ wall polylines */
 
-const mirrorX = (x) => 2 * L.centerX - x;
+function mirrorXRaw(x) {
+  return 2 * L.centerX - x;
+}
+const mirrorX = mirrorXRaw;
 
 // Left outer wall down into the outlane and drain funnel
 L.leftWall = [
@@ -184,7 +203,7 @@ export function buildColliders(world, hooks = {}) {
     restitution: 0.55,
     kick: 8,
     id: 'jackpot',
-    onHit: (v) => hooks.onJackpot && hooks.onJackpot(v)
+    onHit: (v, b) => hooks.onJackpot && hooks.onJackpot(v, b)
   });
   world.add(jack);
   refs.jackpot = jack;
@@ -192,6 +211,19 @@ export function buildColliders(world, hooks = {}) {
   // Decorative posts
   L.posts.forEach((p) => {
     world.add(circle(p.x, p.y, p.r, { restitution: 0.55, onHit: hitWall }));
+  });
+
+  // Scoring switches (sensors). The game layer debounces them.
+  refs.sensors = {};
+  Object.entries(L.sensors).forEach(([id, [ax, ay, bx, by]]) => {
+    refs.sensors[id] = world.add(
+      segment(ax, ay, bx, by, {
+        radius: 0.3,
+        sensor: true,
+        id,
+        onHit: (v, b) => hooks.onSensor && hooks.onSensor(id, v, b)
+      })
+    );
   });
 
   // Flippers

--- a/src/styles/games.css
+++ b/src/styles/games.css
@@ -620,3 +620,115 @@ body.game-open {
     animation: none;
   }
 }
+
+/* ---- Grenar (mode ladder) chips ---- */
+
+.pb-grenar {
+  position: absolute;
+  top: calc(max(10px, env(safe-area-inset-top)) + 92px);
+  left: 12px;
+  display: flex;
+  gap: 4px;
+}
+
+.pb-gren {
+  display: grid;
+  place-items: center;
+  min-width: 24px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 5px;
+  font-size: 0.58rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: rgba(190, 199, 233, 0.45);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  transition: all var(--t-med) var(--ease-spring);
+}
+
+.pb-gren.won {
+  color: #241a05;
+  background: linear-gradient(140deg, #f2c14e, #d99a2b);
+  border-color: transparent;
+  box-shadow: 0 0 10px rgba(242, 193, 78, 0.6);
+}
+
+.pb-gren.active {
+  color: #dfe5ff;
+  border-color: rgba(124, 140, 248, 0.8);
+  box-shadow: 0 0 12px rgba(124, 140, 248, 0.55);
+  animation: pb-gren-pulse 1s ease-in-out infinite;
+}
+
+@keyframes pb-gren-pulse {
+  50% { transform: translateY(-1px); }
+}
+
+/* ---- Active mode banner ---- */
+
+.pb-mode {
+  position: absolute;
+  top: calc(max(10px, env(safe-area-inset-top)) + 118px);
+  left: 12px;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 0.35rem 0.8rem;
+  border-radius: var(--r-pill);
+  background: rgba(10, 14, 28, 0.72);
+  border: 1px solid rgba(124, 140, 248, 0.5);
+  backdrop-filter: blur(8px);
+}
+
+.pb-mode[hidden] {
+  display: none;
+}
+
+.pb-mode-name {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: #aeb9ff;
+}
+
+.pb-mode-task {
+  font-size: 0.66rem;
+  font-weight: 600;
+  color: rgba(210, 217, 245, 0.8);
+}
+
+.pb-mode-time {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  color: #fff;
+}
+
+.pb-mode-time.urgent {
+  color: #f26d8d;
+  animation: pb-time-blink 0.5s steps(2) infinite;
+}
+
+@keyframes pb-time-blink {
+  50% { opacity: 0.4; }
+}
+
+/* ---- Substatus (locks, bonus, hints) ---- */
+
+.pb-substatus {
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: rgba(242, 193, 78, 0.85);
+  text-align: right;
+  white-space: nowrap;
+}
+
+/* ---- Extra ball dot ---- */
+
+.pb-ball-dot.extra {
+  background: linear-gradient(140deg, #f2c14e, #d99a2b);
+  box-shadow: 0 0 10px rgba(242, 193, 78, 0.8);
+}


### PR DESCRIPTION
Takes the flipper game to Medieval Madness territory with a full rules engine:

## Grenar (timed modes)
Complete the POKAL target bank → shoot the **left orbit** to start one of five timed modes, each themed on a real Pekkas Pokal year:

| Gren | År | Uppdrag |
| --- | --- | --- |
| Gokart | '12 | 3 orbits på 35 s |
| Femkamp | '13 | 5 valfria skott på 60 s |
| Pingis | '19 | 12 bumperträffar på 35 s |
| Skytte | '22 | Målen i exakt ordning på 45 s |
| Fiske | '24 | 3 pokalträffar på 35 s |

Completing a mode scores 15 000 and lights its year chip in the HUD. Two completed modes award an **extra ball**.

## FINALEN (wizard mode)
All five modes → 60-second 3-ball multiball where **everything counts ×5**, with warm gold lighting and boosted bloom.

## Multiball
Bumper hits charge the lock; a lit lock makes the golden trophy **lock balls** (shown parked on the playfield). Two locks → 2-ball multiball with a 25 000 trophy jackpot, orbit relights and a 12 s ball save. The physics engine now steps multiple balls with elastic ball-ball collisions.

## Combos, skill & bonus
- Any two shots within 3.5 s chain a combo: 1 000 × 2 per step, up to ×16, with an on-screen toast.
- **Super skill shot**: skill-shot launch + left orbit within 3 s = 15 000.
- Inlanes raise the bonus multiplier (up to ×6) applied to the end-of-ball bonus.

## Engine & HUD
- New detect-only **sensor** colliders (orbits, inlanes) with debounce; per-ball drain and stuck-ball rescue; multi-ball aware nudge and camera parallax.
- HUD: year-chip ladder, mode banner with countdown (blinks under 10 s), gold substatus line, extra-ball pips.
- New synthesized SFX for orbits, combos, locks, multiball, mode start/win, extra ball.

## Verification
- Node physics harness: 7/7 suites (ball-ball separation ≥ 2r, sensors fire, no NaN).
- Playwright rules tests: bank→mode start, combo chain ×6, locks→multiball with the second ball visible, jackpot 25 000 + orbit relight, bonus X.
- Full ladder run: all five modes complete → FINALEN starts with 3 balls, multiball flag and ×5 scoring; extra ball at two modes; Skytte order enforced; **zero console errors**.
- Site-wide smoke test (all tabs + game boot + play): zero console errors. ESLint 0 errors.

README updated with the new rules table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb)_