### PR TITLE
Pinball: Medieval Madness table — castle, wireform ramps, real outlanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,21 @@ Släpp avfyraren när mätaren står i det turkosa fältet för en **skill shot*
 och skjut vänster orbit inom tre sekunder för en **super skill shot** (15 000).
 Fyra nudgar för snabbt ger TILT och dödar flipprarna för den bollen.
 
-**Regler (à la Medieval Madness)**
+**Bordet (à la Medieval Madness)**
+
+Högst upp står **BORGEN** med torn, port och pokalen på borggården. Två
+flippervägar korsar bordet som äkta wireform-ramper: **Kungsvägen** (vänster
+rampfil, bredvid vänster orbit) och **Vallgraven** (ett hårt skott i höger
+orbit) — bollen lyfter ur spelplanen och åker över borgen till motsatt
+inbana. Nedtill finns riktiga **utbanor**: bollen kan rulla ut vid sidan av
+flipprarna, precis som på ett riktigt bord.
 
 | Moment | Så funkar det |
 | --- | --- |
-| **Grenar** | Fäll hela POKAL-banken → skjut vänster orbit för att starta en gren på tid: Gokart '12, Femkamp '13, Pingis '19, Skytte '22 (träffa målen i ordning!), Fiske '24. Klarad gren = 15 000 och en tänd årsbricka. |
+| **Porten** | Tre smällar på borgporten fäller vindbryggan i 9 sekunder. Porten öppnas också av tänt lås, tänd jackpot, FISKE och FINALEN. |
+| **Grenar** | Fäll hela POKAL-banken (P-O-K till vänster, A-L till höger) → skjut vänster orbit för att starta en gren på tid: Gokart '12 (varv: orbit/ramp), Femkamp '13, Pingis '19, Skytte '22 (i ordning!), Fiske '24 (pokalen i borgen). Klarad gren = 15 000 och en tänd årsbricka. |
 | **FINALEN** | Klara alla fem grenar → wizard mode: 60 sekunder multiball där **allt räknas ×5**. |
-| **Multiball** | Bumperträffar laddar låset — när det lyser låser pokalen bollar. Två låsta bollar startar multiball med jackpot (25 000) i pokalen; orbits tänder om jackpotten. |
+| **Multiball** | Bumperträffar laddar låset — då öppnas porten och pokalen låser bollar i borgen. Två låsta bollar startar multiball med jackpot (25 000) i pokalen; orbits och ramper tänder om jackpotten. |
 | **Kombo** | Träffar inom 3,5 sekunder kedjar: 1 000 × 2 per steg, upp till ×16. |
 | **Bonus** | Inbanorna höjer bonusmultiplikatorn (upp till ×6) som multiplicerar slutbonusen per boll. |
 | **Extraboll** | Två klarade grenar ger en extra boll. |

--- a/src/games/pinball/index.js
+++ b/src/games/pinball/index.js
@@ -91,6 +91,19 @@ class Sfx {
     [0, 70, 140, 210, 320].forEach((d, i) => setTimeout(() => this.tone(392 * 2 ** (i / 6), 0.2, 'square', 0.4), d));
   }
   orbit() { this.tone(340, 0.14, 'sawtooth', 0.3, 500); }
+  ramp() {
+    this.tone(240, 0.34, 'sawtooth', 0.4, 640);
+    setTimeout(() => this.tone(660, 0.18, 'triangle', 0.35, 220), 180);
+  }
+  gate() {
+    this.noise(0.09, 0.5, 340);
+    this.tone(95, 0.22, 'square', 0.5, -30);
+  }
+  gateDown() {
+    this.noise(0.2, 0.55, 240);
+    [0, 110, 220].forEach((d, i) => setTimeout(() => this.tone(147 * (i + 1), 0.22, 'square', 0.5), d));
+  }
+  outlane() { this.tone(330, 0.3, 'sine', 0.4, -180); }
   combo(n) { this.tone(440 * 1.25 ** Math.min(n, 6), 0.12, 'square', 0.45, 180); }
   lock() {
     this.tone(120, 0.3, 'square', 0.55, -40);
@@ -266,9 +279,13 @@ export async function createPinball(container, opts = {}) {
   });
 
   // Bumper ring materials are cloned so each bumper can show its own
-  // charged state on the way to lighting the lock.
+  // charged state on the way to lighting the lock. Sling faces likewise,
+  // since the shared glow material now also colours the castle flags.
   refs.bumpers.forEach((b) => {
     b.ring.material = b.ring.material.clone();
+  });
+  [refs.leftSling, refs.rightSling].forEach((m) => {
+    m.material = m.material.clone();
   });
 
   /* ---- Lights ---- */
@@ -312,11 +329,11 @@ export async function createPinball(container, opts = {}) {
    * five and the left orbit starts FINALEN, the wizard mode.
    */
   const MODES = [
-    { id: 'gokart', year: 2012, name: 'GOKART', hint: 'Kör 3 varv i orbit', goal: 3, time: 35 },
-    { id: 'femkamp', year: 2013, name: 'FEMKAMP', hint: 'Träffa alla 5 olika skott', goal: 5, time: 60 },
+    { id: 'gokart', year: 2012, name: 'GOKART', hint: 'Kör 3 varv — orbit eller ramp', goal: 3, time: 35 },
+    { id: 'femkamp', year: 2013, name: 'FEMKAMP', hint: 'Träffa 5 olika skott', goal: 5, time: 60 },
     { id: 'pingis', year: 2019, name: 'PINGIS', hint: '12 bumperträffar', goal: 12, time: 35 },
     { id: 'skytte', year: 2022, name: 'SKYTTE', hint: 'Fäll P→O→K→A→L i ordning', goal: 5, time: 45 },
-    { id: 'fiske', year: 2024, name: 'FISKE', hint: '3 napp på pokalen', goal: 3, time: 35 }
+    { id: 'fiske', year: 2024, name: 'FISKE', hint: '3 napp på pokalen i borgen', goal: 3, time: 40 }
   ];
 
   const state = {
@@ -335,13 +352,18 @@ export async function createPinball(container, opts = {}) {
     lastToast: 0,
 
     // Locks & multiball
-    bumperHits: [0, 0, 0],
-    bumperLit: [false, false, false],
+    bumperHits: [0, 0],
+    bumperLit: [false, false],
     lockLit: false,
     locked: 0,
     multiball: false,
     jackpotLit: false,
     mbSaveUntil: 0,
+
+    // Castle gate: bashed open with 3 hits, or held open by locks/modes
+    gate: { hits: 0, until: 0 },
+    // Balls riding a wireform ramp, outside the 2D simulation
+    riders: [],
 
     // Grenar (modes)
     modeDone: new Set(),
@@ -353,7 +375,7 @@ export async function createPinball(container, opts = {}) {
     combo: { n: 0, t: 0 },
     bonusX: 1,
     inlanes: { left: false, right: false },
-    perBall: { bumps: 0, targets: 0, orbits: 0 },
+    perBall: { bumps: 0, targets: 0, orbits: 0, ramps: 0 },
     extraBalls: 0,
     extraBallGiven: false,
     superUntil: 0,
@@ -467,16 +489,17 @@ export async function createPinball(container, opts = {}) {
     const m = state.mode;
     if (!m || m.wizard) return;
     const { id } = m.def;
+    const isLap =
+      kind === 'leftOrbit' || kind === 'rightOrbit' || kind === 'leftRamp' || kind === 'rightRamp';
     if (
-      (id === 'gokart' && (kind === 'leftOrbit' || kind === 'rightOrbit')) ||
+      (id === 'gokart' && isLap) ||
       (id === 'pingis' && kind === 'bumper') ||
       (id === 'fiske' && kind === 'jackpot')
     ) {
       m.progress++;
     } else if (id === 'femkamp') {
-      const bucket = kind === 'leftOrbit' || kind === 'rightOrbit' ? kind : kind;
-      if (!m.seen.has(bucket)) {
-        m.seen.add(bucket);
+      if (!m.seen.has(kind)) {
+        m.seen.add(kind);
         m.progress = m.seen.size;
         toast(`FEMKAMP ${m.progress}/5`);
       }
@@ -498,7 +521,7 @@ export async function createPinball(container, opts = {}) {
       // Charge the bumpers toward lighting the lock
       if (!state.multiball && state.locked < 2 && !(state.mode && state.mode.wizard)) {
         state.bumperHits[i]++;
-        if (state.bumperHits[i] >= 4 && !state.bumperLit[i]) {
+        if (state.bumperHits[i] >= 6 && !state.bumperLit[i]) {
           state.bumperLit[i] = true;
           refs.bumpers[i].ring.material.emissiveIntensity = 2.6;
           toast('Bumper laddad!');
@@ -506,11 +529,30 @@ export async function createPinball(container, opts = {}) {
         if (state.bumperLit.every(Boolean) && !state.lockLit) {
           state.lockLit = true;
           sfx.modeStart();
-          toast('LÅS TÄNT — SKJUT POKALEN!', true);
+          toast('LÅS TÄNT — PORTEN ÖPPNAS!', true);
           updateStatus();
         }
       }
       modeEvent('bumper');
+    },
+    onGate(v, _b) {
+      if (v < 1.2) return;
+      const now = performance.now();
+      if (now - (state.sensorLast.gate || 0) < 350) return;
+      state.sensorLast.gate = now;
+      state.gate.hits++;
+      addScore(750);
+      sfx.gate();
+      startShake(0.5, 0);
+      if (state.gate.hits >= 3) {
+        state.gate.hits = 0;
+        state.gate.until = now + 9000;
+        sfx.gateDown();
+        flash(null, refs.castle.lamp, 3.2, 0.6);
+        toast('PORTEN NERE — STORMA BORGEN!', true);
+      } else {
+        toast(state.gate.hits === 1 ? 'PORTEN SKAKAR!' : 'EN SMÄLL TILL!');
+      }
     },
     onSling(side, v) {
       if (v < 1) return;
@@ -612,11 +654,28 @@ export async function createPinball(container, opts = {}) {
       comboShot();
       modeEvent('jackpot');
     },
-    onSensor(id, _v, _b) {
+    onSensor(id, _v, b) {
       const now = performance.now();
       if (now - (state.sensorLast[id] || 0) < 700) return;
       state.sensorLast[id] = now;
       if (state.phase !== 'play') return;
+
+      // Wireform ramps: a fast, climbing ball is captured and carried across
+      if (id === 'leftRamp' || id === 'rightRamp') {
+        const side = id === 'leftRamp' ? 'left' : 'right';
+        if (b && b.live && b.vy > L.ramps[side].minVy) captureRamp(side, b);
+        return;
+      }
+
+      // Outlanes: the ball is on its way out past the flipper
+      if (id === 'outLeft' || id === 'outRight') {
+        if (b && b.vy < 0) {
+          addScore(500);
+          sfx.outlane();
+          toast('UTBANAN!');
+        }
+        return;
+      }
 
       if (id === 'inlaneLeft' || id === 'inlaneRight') {
         const side = id === 'inlaneLeft' ? 'left' : 'right';
@@ -791,10 +850,10 @@ export async function createPinball(container, opts = {}) {
     updateStatus();
 
     if (state.locked >= 2) {
-      toast('BOLL 2 LÅST…', true);
+      toast('BOLL 2 LÅST I BORGEN…', true);
       setTimeout(startMultiball, 900);
     } else {
-      toast(`BOLL LÅST ${state.locked}/2`, true);
+      toast(`BOLL LÅST I BORGEN ${state.locked}/2`, true);
       serveBall(700);
     }
   }
@@ -808,16 +867,73 @@ export async function createPinball(container, opts = {}) {
     toast('MULTIBALL!', true);
     bloom.strength = 0.72;
 
-    // Release the locked balls into play
-    L.lockSlots.forEach((slot, i) => {
+    // The locked balls burst out through the castle gate into the forecourt.
+    // They spawn just below the gate mouth: the courtyard itself is too
+    // cramped to release into without clipping the towers or the trophy.
+    [
+      { x: -1.9, y: 27.0, vx: -4 },
+      { x: 0.2, y: 27.0, vx: 4 }
+    ].forEach((spot, i) => {
       lockMeshes[i].visible = false;
       const nb = new Ball(L.ballRadius);
-      nb.place(slot.x, slot.y, 7 + i * 2, -5);
+      nb.place(spot.x, spot.y, spot.vx, -9);
       nb.live = true;
       state.balls.push(nb);
     });
     state.locked = 0;
     updateStatus();
+  }
+
+  /* ======================= Wireform ramps ======================= */
+
+  /**
+   * Lifts a ball out of the 2D world and rides it along the wireform.
+   * The mesh follows the 3D curve; on arrival the ball rejoins the
+   * simulation at the opposite inlane, Medieval Madness style.
+   */
+  function captureRamp(side, b) {
+    const idx = state.balls.indexOf(b);
+    if (idx < 0) return;
+    state.balls.splice(idx, 1);
+    b.live = false;
+    state.riders.push({ ball: b, side, t: 0, dur: side === 'left' ? 2.0 : 2.4 });
+
+    addScore(3000);
+    state.perBall.ramps++;
+    sfx.ramp();
+    comboShot();
+    modeEvent(side === 'left' ? 'leftRamp' : 'rightRamp');
+    toast(side === 'left' ? 'KUNGSVÄGEN!' : 'VALLGRAVEN!');
+
+    // Like the orbits, a ramp relights the multiball jackpot
+    if (state.multiball && !state.jackpotLit) {
+      state.jackpotLit = true;
+      toast('JACKPOT TÄND — SKJUT POKALEN!', true);
+      updateStatus();
+    }
+  }
+
+  function releaseRider(r) {
+    const ex = L.ramps[r.side].exit;
+    r.ball.place(ex.x, ex.y, r.side === 'left' ? -0.6 : 0.6, ex.vy);
+    r.ball.live = true;
+    state.balls.push(r.ball);
+  }
+
+  /* ======================== Castle gate ========================= */
+
+  /**
+   * The gate is open while something inside the castle is wanted: a lit
+   * lock, a lit multiball jackpot, FISKE or FINALEN — or for a while after
+   * being bashed down with three hits.
+   */
+  function gateIsOpen() {
+    return (
+      state.lockLit ||
+      (state.multiball && state.jackpotLit) ||
+      (state.mode && (state.mode.wizard || state.mode.def.id === 'fiske')) ||
+      performance.now() < state.gate.until
+    );
   }
 
   function endMultiball() {
@@ -893,12 +1009,14 @@ export async function createPinball(container, opts = {}) {
     if (idx >= 0) state.balls.splice(idx, 1);
     b.live = false;
 
-    if (state.balls.length >= 1) {
+    // A ball riding a wireform still counts as in play
+    const inPlay = state.balls.length + state.riders.length;
+    if (inPlay >= 1) {
       // Multiball continues — respawn during the grace window
       if (performance.now() < state.mbSaveUntil) {
         toast('Boll räddad!');
         serveBall(400);
-      } else if (state.balls.length === 1 && state.multiball && !(state.mode && state.mode.wizard)) {
+      } else if (inPlay === 1 && state.multiball && !(state.mode && state.mode.wizard)) {
         endMultiball();
       }
       return;
@@ -929,7 +1047,8 @@ export async function createPinball(container, opts = {}) {
 
     // End-of-ball bonus
     const pb = state.perBall;
-    const bonus = (pb.bumps * 50 + pb.targets * 300 + pb.orbits * 500) * state.bonusX;
+    const bonus =
+      (pb.bumps * 50 + pb.targets * 300 + pb.orbits * 500 + pb.ramps * 400) * state.bonusX;
     if (bonus > 0) {
       setTimeout(() => {
         state.score += bonus;
@@ -938,7 +1057,7 @@ export async function createPinball(container, opts = {}) {
         toast(`BONUS +${fmt(bonus)}${state.bonusX > 1 ? ` (×${state.bonusX})` : ''}`, true);
       }, 700);
     }
-    state.perBall = { bumps: 0, targets: 0, orbits: 0 };
+    state.perBall = { bumps: 0, targets: 0, orbits: 0, ramps: 0 };
     state.bonusX = 1;
     state.inlanes = { left: false, right: false };
     state.combo = { n: 0, t: 0 };
@@ -1000,13 +1119,15 @@ export async function createPinball(container, opts = {}) {
     state.banksDone = 0;
     state.tilted = false;
     state.nudges = [];
-    state.bumperHits = [0, 0, 0];
-    state.bumperLit = [false, false, false];
+    state.bumperHits = [0, 0];
+    state.bumperLit = [false, false];
     state.lockLit = false;
     state.locked = 0;
     state.multiball = false;
     state.jackpotLit = false;
     state.mbSaveUntil = 0;
+    state.gate = { hits: 0, until: 0 };
+    state.riders = [];
     state.modeDone = new Set();
     state.mode = null;
     state.modeStartLit = false;
@@ -1014,7 +1135,7 @@ export async function createPinball(container, opts = {}) {
     state.combo = { n: 0, t: 0 };
     state.bonusX = 1;
     state.inlanes = { left: false, right: false };
-    state.perBall = { bumps: 0, targets: 0, orbits: 0 };
+    state.perBall = { bumps: 0, targets: 0, orbits: 0, ramps: 0 };
     state.extraBalls = 0;
     state.extraBallGiven = false;
     state.superUntil = 0;
@@ -1203,7 +1324,7 @@ export async function createPinball(container, opts = {}) {
   const pitch = 67 * (Math.PI / 180);
   const dir = new THREE.Vector3(0, Math.sin(pitch), Math.cos(pitch));
   const corners = [];
-  for (const x of [-L.outerX - 0.35, L.outerX + 0.35]) {
+  for (const x of [-L.flareX - 0.35, L.outerX + 0.35]) {
     for (const z of [0.5, -41.5]) {
       corners.push(new THREE.Vector3(x, 0, z));
       corners.push(new THREE.Vector3(x, 2, z));
@@ -1322,6 +1443,34 @@ export async function createPinball(container, opts = {}) {
       }
     }
 
+    // Riders travel their wireform, then rejoin the simulation
+    if (state.phase === 'play') {
+      for (let ri = state.riders.length - 1; ri >= 0; ri--) {
+        const r = state.riders[ri];
+        r.t += dtRaw / r.dur;
+        if (r.t >= 1) {
+          state.riders.splice(ri, 1);
+          releaseRider(r);
+        }
+      }
+    }
+
+    // Castle gate: the collider blocks only while the gate is closed, and the
+    // drawbridge/portcullis animate toward the current state.
+    {
+      const open = gateIsOpen();
+      colliderRefs.gate.enabled = !open;
+      const k = Math.min(1, dtRaw * 6);
+      const { bridge } = refs.castle;
+      const wantRot = open ? 0.04 : -Math.PI / 2 + 0.12;
+      bridge.rotation.x += (wantRot - bridge.rotation.x) * k;
+      const port = refs.castle.portcullis;
+      const wantY = open ? 3.35 : 1.88;
+      port.position.y += (wantY - port.position.y) * k;
+      refs.castle.lamp.intensity +=
+        ((open ? 1.4 : 0.6) - refs.castle.lamp.intensity) * k;
+    }
+
     // Mode HUD
     if (state.mode) {
       const m = state.mode;
@@ -1334,21 +1483,32 @@ export async function createPinball(container, opts = {}) {
       hud.modeTime.classList.toggle('urgent', secs <= 10);
     }
 
-    // Ball transforms + rolling spin (mesh pool)
-    for (let i = 0; i < ballMeshes.length; i++) {
-      const mesh = ballMeshes[i];
-      const b = state.balls[i];
-      if (b && b.live) {
-        mesh.visible = true;
-        mesh.position.set(b.x, L.ballRadius + 0.04, -b.y);
-        if (b.speed > 0.01) {
-          const axis = new THREE.Vector3(-b.vy, 0, -b.vx).normalize();
-          mesh.rotateOnWorldAxis(axis, (b.speed * dtRaw) / L.ballRadius);
-        }
-      } else {
-        mesh.visible = false;
+    // Ball transforms + rolling spin (mesh pool). Balls riding a wireform are
+    // drawn at their 3D curve position instead of on the playfield plane.
+    let meshIdx = 0;
+    for (const b of state.balls) {
+      if (!b.live || meshIdx >= ballMeshes.length) continue;
+      const mesh = ballMeshes[meshIdx++];
+      mesh.visible = true;
+      mesh.position.set(b.x, L.ballRadius + 0.04, -b.y);
+      if (b.speed > 0.01) {
+        const axis = new THREE.Vector3(-b.vy, 0, -b.vx).normalize();
+        mesh.rotateOnWorldAxis(axis, (b.speed * dtRaw) / L.ballRadius);
       }
     }
+    for (const r of state.riders) {
+      if (meshIdx >= ballMeshes.length) break;
+      const mesh = ballMeshes[meshIdx++];
+      mesh.visible = true;
+      const p = refs.rampCurves[r.side].getPointAt(Math.min(1, r.t));
+      mesh.position.set(p.x, p.y + L.ballRadius, p.z);
+      const tan = refs.rampCurves[r.side].getTangentAt(Math.min(1, r.t));
+      mesh.rotateOnWorldAxis(
+        new THREE.Vector3(tan.z, 0, -tan.x).normalize(),
+        (dtRaw * 16) / (2 * Math.PI * L.ballRadius)
+      );
+    }
+    for (; meshIdx < ballMeshes.length; meshIdx++) ballMeshes[meshIdx].visible = false;
 
     // Flippers
     // rotation.y = +angle, NOT -angle: the playfield→world mapping (y → −z)
@@ -1452,7 +1612,15 @@ export async function createPinball(container, opts = {}) {
     },
     hitTarget(i) {
       hooks.onTarget(i, 3);
-    }
+    },
+    hitGate() {
+      state.sensorLast.gate = 0;
+      hooks.onGate(3, state.balls[0]);
+    },
+    rideRamp(side) {
+      if (state.balls[0]) captureRamp(side, state.balls[0]);
+    },
+    gateIsOpen
   };
 
   /* ---- Teardown ---- */

--- a/src/games/pinball/meshes.js
+++ b/src/games/pinball/meshes.js
@@ -6,7 +6,7 @@
  * extruded upward and dropped straight in.
  */
 
-import { L, mirrorX } from './table.js';
+import { L, ART, mirrorX } from './table.js';
 
 /** Extruding a shape drawn in playfield space lands it flat, height along +Y. */
 function flatten(geo) {
@@ -96,6 +96,24 @@ export function createMaterials(THREE, playfieldTexture) {
       metalness: 0.9,
       envMapIntensity: 0.5
     }),
+    stone: new THREE.MeshStandardMaterial({
+      color: 0x8b93ad,
+      roughness: 0.82,
+      metalness: 0.12,
+      envMapIntensity: 0.25
+    }),
+    stoneDark: new THREE.MeshStandardMaterial({
+      color: 0x5c6480,
+      roughness: 0.85,
+      metalness: 0.1,
+      envMapIntensity: 0.2
+    }),
+    wood: new THREE.MeshStandardMaterial({
+      color: 0x8a5a2b,
+      roughness: 0.7,
+      metalness: 0.05,
+      envMapIntensity: 0.2
+    }),
     gold: new THREE.MeshStandardMaterial({
       color: 0xf2c14e,
       roughness: 0.26,
@@ -143,6 +161,174 @@ export function createMaterials(THREE, playfieldTexture) {
   };
 }
 
+/* ------------------------------------------------------------------- ramps */
+
+/** World-space curve for a ramp path ([x, y, h] playfield triples). */
+export function rampCurve(THREE, path) {
+  return new THREE.CatmullRomCurve3(
+    path.map(([x, y, h]) => new THREE.Vector3(x, h, -y)),
+    false,
+    'catmullrom',
+    0.35
+  );
+}
+
+/**
+ * A wireform habitrail: two chrome tubes riding either side of the curve,
+ * with periodic U-shaped cross ties. The Medieval Madness look.
+ */
+function buildWireform(THREE, curve, materials) {
+  const g = new THREE.Group();
+  const railR = 0.07;
+  const halfGap = 0.34;
+
+  // Offset each rail horizontally, perpendicular to the path direction
+  [-1, 1].forEach((side) => {
+    const pts = [];
+    for (let i = 0; i <= 60; i++) {
+      const t = i / 60;
+      const p = curve.getPointAt(t);
+      const tan = curve.getTangentAt(t);
+      const perp = new THREE.Vector3(-tan.z, 0, tan.x);
+      const l = perp.length() || 1;
+      pts.push(p.clone().addScaledVector(perp.multiplyScalar(1 / l), side * halfGap));
+    }
+    const railCurve = new THREE.CatmullRomCurve3(pts);
+    const tube = new THREE.Mesh(new THREE.TubeGeometry(railCurve, 90, railR, 7, false), materials.chrome);
+    g.add(tube);
+  });
+
+  // Cross ties: shallow U-loops under the ball path
+  for (let i = 1; i < 12; i++) {
+    const t = i / 12;
+    const p = curve.getPointAt(t);
+    const tan = curve.getTangentAt(t);
+    const tie = new THREE.Mesh(
+      new THREE.TorusGeometry(halfGap, 0.045, 6, 14, Math.PI),
+      materials.rail
+    );
+    tie.position.copy(p).y -= 0.06;
+    tie.rotation.z = Math.PI; // open side up
+    tie.rotation.y = Math.atan2(tan.x, tan.z) + Math.PI / 2;
+    g.add(tie);
+  }
+  return g;
+}
+
+/* ------------------------------------------------------------------ castle */
+
+/**
+ * The castle: two round towers with golden cone roofs, a crenellated gate
+ * house, a drawbridge that lowers when the gate opens, and pennant flags.
+ */
+function buildCastle(THREE, materials) {
+  const g = new THREE.Group();
+  const refs = {};
+  const towerH = 3.0;
+
+  L.castle.towers.forEach((t) => {
+    const tower = new THREE.Mesh(
+      new THREE.CylinderGeometry(t.r + 0.12, t.r + 0.22, towerH, 18),
+      materials.stone
+    );
+    tower.position.set(t.x, towerH / 2, -t.y);
+    tower.castShadow = true;
+    g.add(tower);
+
+    const roof = new THREE.Mesh(new THREE.ConeGeometry(t.r + 0.3, 1.1, 18), materials.gold);
+    roof.position.set(t.x, towerH + 0.55, -t.y);
+    roof.castShadow = true;
+    g.add(roof);
+
+    // Pennant flag
+    const pole = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.03, 0.9, 6), materials.chrome);
+    pole.position.set(t.x, towerH + 1.5, -t.y);
+    g.add(pole);
+    const flag = new THREE.Mesh(new THREE.PlaneGeometry(0.55, 0.3), materials.blueGlow);
+    flag.position.set(t.x + 0.28, towerH + 1.75, -t.y);
+    flag.material = materials.blueGlow;
+    g.add(flag);
+  });
+
+  // Battlement walls above the physics walls
+  const wallH = 2.1;
+  [L.castle.leftWall, L.castle.rightWall].forEach((pts) => {
+    for (let i = 0; i < pts.length - 1; i++) {
+      const [ax, ay] = pts[i];
+      const [bx, by] = pts[i + 1];
+      const lenW = Math.hypot(bx - ax, by - ay);
+      const wall = new THREE.Mesh(new THREE.BoxGeometry(lenW, wallH, 0.5), materials.stone);
+      wall.position.set((ax + bx) / 2, wallH / 2, -(ay + by) / 2);
+      wall.rotation.y = Math.atan2(by - ay, bx - ax);
+      wall.castShadow = true;
+      g.add(wall);
+      // Crenellations: small merlon blocks along the top
+      const n = Math.max(2, Math.round(lenW / 0.55));
+      for (let k = 0; k < n; k += 2) {
+        const f = (k + 0.5) / n;
+        const merlon = new THREE.Mesh(new THREE.BoxGeometry(0.28, 0.3, 0.5), materials.stoneDark);
+        merlon.position.set(
+          ax + (bx - ax) * f,
+          wallH + 0.15,
+          -(ay + (by - ay) * f)
+        );
+        merlon.rotation.y = Math.atan2(by - ay, bx - ax);
+        g.add(merlon);
+      }
+    }
+  });
+
+  // Gate house: an arch over the gate opening
+  const [gax, gay, gbx] = L.castle.gate;
+  const gateW = Math.abs(gbx - gax);
+  const gateCx = (gax + gbx) / 2;
+  const lintel = new THREE.Mesh(new THREE.BoxGeometry(gateW + 0.7, 0.55, 0.65), materials.stoneDark);
+  lintel.position.set(gateCx, 2.15, -gay);
+  lintel.castShadow = true;
+  g.add(lintel);
+  const crown = new THREE.Mesh(new THREE.BoxGeometry(gateW + 0.4, 0.28, 0.6), materials.stone);
+  crown.position.set(gateCx, 2.55, -gay);
+  g.add(crown);
+
+  // Portcullis: drops with the gate closed, lifts when it opens
+  const portcullis = new THREE.Group();
+  for (let i = 0; i <= 4; i++) {
+    const bar = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.05, 1.85, 6), materials.rail);
+    bar.position.set(gax + (gateW * i) / 4, -0.92, 0);
+    portcullis.add(bar);
+  }
+  const cross = new THREE.Mesh(new THREE.BoxGeometry(gateW + 0.15, 0.09, 0.09), materials.rail);
+  cross.position.set(gateCx, -0.8, 0);
+  portcullis.add(cross);
+  // Bars are laid out in absolute playfield x, so the group only lifts them
+  portcullis.position.set(0, 1.88, -gay);
+  g.add(portcullis);
+  refs.portcullis = portcullis;
+
+  // Drawbridge: hinged plank in front of the gate
+  const bridge = new THREE.Group();
+  const plank = new THREE.Mesh(new THREE.BoxGeometry(gateW + 0.3, 0.12, 1.9), materials.wood);
+  plank.position.z = -0.95;
+  bridge.add(plank);
+  [0.32, -0.32].forEach((off) => {
+    const strap = new THREE.Mesh(new THREE.BoxGeometry(0.09, 0.14, 1.9), materials.rail);
+    strap.position.set(off * gateW, 0.02, -0.95);
+    bridge.add(strap);
+  });
+  bridge.position.set(gateCx, 0.1, -(gay - 0.35));
+  bridge.rotation.x = -Math.PI / 2 + 0.12; // raised (closed)
+  g.add(bridge);
+  refs.bridge = bridge;
+
+  // Courtyard glow
+  const lamp = new THREE.PointLight(0xf2c14e, 0.6, 9, 2);
+  lamp.position.set(L.centerX, 2.6, -(gay + 1.6));
+  g.add(lamp);
+  refs.lamp = lamp;
+
+  return { group: g, refs };
+}
+
 /* ------------------------------------------------------------------ builder */
 
 export function buildTable(THREE, mergeGeometries, materials) {
@@ -150,24 +336,22 @@ export function buildTable(THREE, mergeGeometries, materials) {
   const refs = { bumpers: [], targets: [], flippers: {}, lights: [] };
 
   /* ---- Playfield ---- */
-  const artW = L.outerX * 2 + 1.2;
-  const artH = 44;
-  // No extra spin: the plane's +y becomes world -z, which is up-table, so the
-  // canvas lands the right way up with the title at the top of the playfield.
+  const artW = ART.x1 - ART.x0;
+  const artH = ART.y1 - ART.y0;
   const playfield = new THREE.Mesh(
     flatten(new THREE.PlaneGeometry(artW, artH, 1, 1)),
     materials.playfield
   );
-  // PlaneGeometry is centred; ART spans y -2..42 → centre 20
-  playfield.position.set(0, 0, -20);
+  playfield.position.set((ART.x0 + ART.x1) / 2, 0, -(ART.y0 + ART.y1) / 2);
   playfield.receiveShadow = true;
   group.add(playfield);
 
   /* ---- Walls ---- */
   const wallShapes = [];
-  const pushChain = (pts, r = 0.3) => {
+  const railShapes = [];
+  const pushChain = (pts, r = 0.3, into = wallShapes) => {
     for (let i = 0; i < pts.length - 1; i++) {
-      wallShapes.push(capsuleShape(THREE, pts[i][0], pts[i][1], pts[i + 1][0], pts[i + 1][1], r));
+      into.push(capsuleShape(THREE, pts[i][0], pts[i][1], pts[i + 1][0], pts[i + 1][1], r));
     }
   };
   const pushArc = (cx, cy, radius, from, to, steps, r = 0.3) => {
@@ -187,8 +371,15 @@ export function buildTable(THREE, mergeGeometries, materials) {
   pushChain([[L.laneX, L.laneBottomY], [L.outerX, L.laneBottomY]]);
   pushArc(0, L.domeY, L.domeOuterR, 0, 180 * D, 34);
   pushArc(0, L.domeY, L.domeInnerR, 0, 130 * D, 22);
-  pushChain(L.leftGuide);
-  pushChain(L.rightGuide);
+
+  // Lane dividers and guide rails, slimmer and lower than the outer walls
+  pushChain(L.leftDivider, 0.22, railShapes);
+  pushChain(L.leftRampInner, 0.22, railShapes);
+  pushChain(L.leftRail, 0.22, railShapes);
+  pushChain(L.rightRail, 0.22, railShapes);
+  // One-way return gates read as thin wires
+  pushChain(L.leftReturnGate, 0.09, railShapes);
+  pushChain(L.rightReturnGate, 0.09, railShapes);
 
   const wallGeos = wallShapes.map((s) =>
     flatten(new THREE.ExtrudeGeometry(s, { depth: L.wallH, bevelEnabled: false }))
@@ -198,18 +389,39 @@ export function buildTable(THREE, mergeGeometries, materials) {
   walls.receiveShadow = true;
   group.add(walls);
 
-  /* ---- Slingshots (glowing rubber faces) ---- */
-  [L.leftSling, L.rightSling].forEach((s) => {
-    const geo = flatten(
-      new THREE.ExtrudeGeometry(capsuleShape(THREE, s[0][0], s[0][1], s[1][0], s[1][1], 0.32), {
-        depth: L.wallH,
-        bevelEnabled: false
-      })
+  const railGeos = railShapes.map((s) =>
+    flatten(new THREE.ExtrudeGeometry(s, { depth: 1.0, bevelEnabled: false }))
+  );
+  const rails = new THREE.Mesh(mergeGeometries(railGeos), materials.chrome);
+  rails.castShadow = true;
+  group.add(rails);
+
+  /* ---- Slingshots: rubber triangle body + glowing kicker face ---- */
+  [['leftSling', L.leftSlingPts], ['rightSling', L.rightSlingPts]].forEach(([name, P]) => {
+    const tri = new THREE.Shape();
+    tri.moveTo(P.T[0], P.T[1]);
+    tri.lineTo(P.BO[0], P.BO[1]);
+    tri.lineTo(P.BI[0], P.BI[1]);
+    tri.closePath();
+    const body = new THREE.Mesh(
+      flatten(new THREE.ExtrudeGeometry(tri, { depth: L.wallH * 0.8, bevelEnabled: false })),
+      materials.rubber
     );
-    const mesh = new THREE.Mesh(geo, materials.blueGlow);
-    mesh.castShadow = true;
-    group.add(mesh);
-    refs[s === L.leftSling ? 'leftSling' : 'rightSling'] = mesh;
+    body.castShadow = true;
+    group.add(body);
+
+    const face = new THREE.Mesh(
+      flatten(
+        new THREE.ExtrudeGeometry(
+          capsuleShape(THREE, P.T[0], P.T[1], P.BI[0], P.BI[1], 0.24),
+          { depth: L.wallH * 0.85, bevelEnabled: false }
+        )
+      ),
+      materials.blueGlow
+    );
+    face.castShadow = true;
+    group.add(face);
+    refs[name] = face;
   });
 
   /* ---- Posts ---- */
@@ -252,43 +464,27 @@ export function buildTable(THREE, mergeGeometries, materials) {
     cap.castShadow = true;
     g.add(cap);
 
-    let trophy = null;
-    if (b.trophy) {
-      // The centre bumper is a proper golden pokal on a plinth
-      const plinth = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.52, 0.66, 0.24, 22),
-        materials.rubber
-      );
-      plinth.position.y = 0.99;
-      plinth.castShadow = true;
-      g.add(plinth);
+    const dome = new THREE.Mesh(
+      new THREE.SphereGeometry(L.bumperR * 0.6, 22, 14, 0, Math.PI * 2, 0, Math.PI / 2),
+      materials.goldGlow
+    );
+    dome.position.y = 0.94;
+    dome.castShadow = true;
+    g.add(dome);
 
-      trophy = buildTrophy(THREE, materials.gold, 1.5);
-      trophy.position.y = 1.06;
-      g.add(trophy);
-    } else {
-      const dome = new THREE.Mesh(
-        new THREE.SphereGeometry(L.bumperR * 0.6, 22, 14, 0, Math.PI * 2, 0, Math.PI / 2),
-        materials.goldGlow
-      );
-      dome.position.y = 0.94;
-      dome.castShadow = true;
-      g.add(dome);
-      trophy = dome;
-    }
-
-    const light = new THREE.PointLight(0xf2c14e, b.trophy ? 0.55 : 0, b.trophy ? 9 : 7, 2);
+    const light = new THREE.PointLight(0xf2c14e, 0, 7, 2);
     light.position.y = 1.9;
     g.add(light);
 
     group.add(g);
-    refs.bumpers.push({ group: g, ring, trophy, light, base: b.trophy ? 0.55 : 0, isTrophy: !!b.trophy });
+    refs.bumpers.push({ group: g, ring, trophy: dome, light, base: 0, isTrophy: false });
   });
 
-  /* ---- Drop targets ---- */
+  /* ---- Drop targets (angled banks) ---- */
   L.targets.forEach((t) => {
     const g = new THREE.Group();
     g.position.set(t.x, 0, -t.y);
+    g.rotation.y = t.a;
     const face = new THREE.Mesh(
       new THREE.BoxGeometry(t.half * 2, 1.15, 0.42),
       materials.targetUp.clone()
@@ -300,19 +496,24 @@ export function buildTable(THREE, mergeGeometries, materials) {
     refs.targets.push({ group: g, face, down: false });
   });
 
-  /* ---- Jackpot trophy ---- */
+  /* ---- Castle ---- */
+  const castle = buildCastle(THREE, materials);
+  group.add(castle.group);
+  refs.castle = castle.refs;
+
+  /* ---- Jackpot trophy in the courtyard ---- */
   {
     const g = new THREE.Group();
     g.position.set(L.jackpot.x, 0, -L.jackpot.y);
 
     const base = new THREE.Mesh(
       new THREE.CylinderGeometry(L.jackpot.r, L.jackpot.r * 1.1, 0.42, 26),
-      materials.rubber
+      materials.stoneDark
     );
     base.position.y = 0.21;
     g.add(base);
 
-    const trophy = buildTrophy(THREE, materials.gold, 1.85);
+    const trophy = buildTrophy(THREE, materials.gold, 1.75);
     trophy.position.y = 0.42;
     g.add(trophy);
 
@@ -330,6 +531,51 @@ export function buildTable(THREE, mergeGeometries, materials) {
 
     group.add(g);
     refs.jackpot = { group: g, trophy, halo, light };
+  }
+
+  /* ---- Wireform ramps ---- */
+  refs.rampCurves = {};
+  ['left', 'right'].forEach((side) => {
+    const curve = rampCurve(THREE, L.ramps[side].path);
+    refs.rampCurves[side] = curve;
+    group.add(buildWireform(THREE, curve, materials));
+
+    // Entrance portal: a golden arch at the capture point
+    const p0 = curve.getPointAt(0);
+    const arch = new THREE.Mesh(
+      new THREE.TorusGeometry(0.62, 0.09, 8, 18, Math.PI),
+      materials.goldGlow
+    );
+    arch.position.set(p0.x, 0.35, p0.z);
+    const tan = curve.getTangentAt(0);
+    arch.rotation.y = Math.atan2(tan.x, tan.z) + Math.PI / 2;
+    group.add(arch);
+  });
+
+  /* ---- Apron: the angled plate over the drain ---- */
+  {
+    const apron = new THREE.Shape();
+    apron.moveTo(-4.4, -1.6);
+    apron.lineTo(2.0, -1.6);
+    apron.lineTo(0.2, 3.4);
+    apron.lineTo(-2.6, 3.4);
+    apron.closePath();
+    const mesh = new THREE.Mesh(
+      flatten(new THREE.ExtrudeGeometry(apron, { depth: 0.7, bevelEnabled: false })),
+      materials.stoneDark
+    );
+    mesh.castShadow = true;
+    group.add(mesh);
+    const trim = new THREE.Mesh(
+      flatten(
+        new THREE.ExtrudeGeometry(capsuleShape(THREE, -2.6, 3.4, 0.2, 3.4, 0.12), {
+          depth: 0.85,
+          bevelEnabled: false
+        })
+      ),
+      materials.gold
+    );
+    group.add(trim);
   }
 
   /* ---- Flippers ---- */

--- a/src/games/pinball/physics.js
+++ b/src/games/pinball/physics.js
@@ -47,9 +47,14 @@ export function segment(ax, ay, bx, by, opts = {}) {
     restitution: opts.restitution ?? 0.42,
     friction: opts.friction ?? 0.04,
     kick: opts.kick ?? 0,
+    kickMin: opts.kickMin ?? 0,
     // A sensor detects the ball passing through without touching it —
     // used for orbit shots, inlane rollovers and other scoring switches.
     sensor: opts.sensor ?? false,
+    // One-way gates: collide only when `filter(ball)` is true, e.g. only for
+    // descending balls. This is how a real orbit keeps its return path from
+    // dumping every ball into the outlane.
+    filter: opts.filter || null,
     id: opts.id || null,
     onHit: opts.onHit || null,
     enabled: true
@@ -65,7 +70,9 @@ export function circle(cx, cy, radius, opts = {}) {
     restitution: opts.restitution ?? 0.5,
     friction: opts.friction ?? 0.02,
     kick: opts.kick ?? 0,
+    kickMin: opts.kickMin ?? 0,
     sensor: opts.sensor ?? false,
+    filter: opts.filter || null,
     id: opts.id || null,
     onHit: opts.onHit || null,
     enabled: true
@@ -374,6 +381,8 @@ export class World {
   }
 
   resolve(ball, c) {
+    if (c.filter && !c.filter(ball)) return false;
+
     let qx;
     let qy;
 
@@ -422,7 +431,9 @@ export class World {
       ball.vx -= tx * vt * c.friction;
       ball.vy -= ty * vt * c.friction;
 
-      if (c.kick) {
+      // Kickers only fire above their trigger speed — a real slingshot
+      // ignores a ball dribbling against its rubber.
+      if (c.kick && -vn > (c.kickMin ?? 0)) {
         ball.vx += nx * c.kick;
         ball.vy += ny * c.kick;
       }

--- a/src/games/pinball/table.js
+++ b/src/games/pinball/table.js
@@ -6,6 +6,12 @@
  *
  * Playfield coordinates: +y runs up the table, the drain is at y = 0.
  * The shooter lane is on the right, feeding a habitrail around the top dome.
+ *
+ * Anatomy, bottom to top: flippers with real inlanes and OUTLANES (the ball
+ * can drain past the flippers on both sides), slingshot triangles, two angled
+ * P-O-K / A-L target banks framing an open corridor, and at the top the
+ * CASTLE: towers, bashable gate and the trophy in the courtyard. Two wireform
+ * ramps carry the ball in 3D across the table.
  */
 
 import { segment, circle, chain, arc, Flipper } from './physics.js';
@@ -18,8 +24,11 @@ export const L = {
   domeY: 31,
   domeOuterR: 9,
   // Inner radius and divider leave a 1.8 channel — comfortably wider than the
-  // 1.24 ball. Any narrower and the ball wedges in the shooter lane.
+  // ball. Any narrower and the ball wedges in the shooter lane.
   domeInnerR: 6.6,
+  // The left wall flares out below the dome to make room for the ramp lane
+  // beside the left orbit.
+  flareX: 9.7,
 
   // Shooter lane
   laneX: 6.6,
@@ -30,75 +39,133 @@ export const L = {
   // Playfield proper spans -9 .. 6.6
   centerX: -1.2,
 
-  ballRadius: 0.62,
+  ballRadius: 0.54,
 
   // Flippers
   flipperY: 7,
   flipperSpread: 3.7,
-  flipperLength: 3.0,
+  flipperLength: 3.15,
   flipperRest: -30 * D,
   flipperSwing: 62 * D,
 
-  // Slingshots (kicking face, outer → inner)
-  slingTopY: 12.4,
-  slingBotY: 8.4,
-
-  // Bumpers
   bumperR: 1.25,
 
-  wallH: 1.5
+  wallH: 1.7
 };
-
-L.bumpers = [
-  { x: L.centerX - 3.3, y: 26.4 },
-  { x: L.centerX + 3.3, y: 26.4 },
-  { x: L.centerX, y: 29.0, trophy: true }
-];
-
-// P-O-K-A-L drop target bank, with an open orbit lane either side
-L.targets = ['P', 'O', 'K', 'A', 'L'].map((letter, i) => ({
-  letter,
-  x: L.centerX - 4.5 + i * 2.25,
-  y: 19,
-  half: 0.62
-}));
-
-L.jackpot = { x: L.centerX, y: 32.9, r: 1.05 };
-
-L.posts = [
-  { x: L.centerX - 3.4, y: 17.0, r: 0.34 },
-  { x: L.centerX + 3.4, y: 17.0, r: 0.34 },
-  { x: L.centerX, y: 23.2, r: 0.3 },
-  { x: L.centerX - 5.2, y: 22.6, r: 0.3 },
-  { x: L.centerX + 5.2, y: 22.6, r: 0.3 }
-];
-
-// Scoring switches: invisible sensors the ball rolls through.
-// Orbits are the open lanes either side of the target bank; inlanes are the
-// return channels that feed the flippers.
-L.sensors = {
-  leftOrbit: [-8.6, 18, -6.6, 18],
-  rightOrbit: [4.2, 18, 6.2, 18],
-  inlaneLeft: [-5.55, 6.6, -4.35, 7.1],
-  inlaneRight: [mirrorXRaw(-5.55), 6.6, mirrorXRaw(-4.35), 7.1]
-};
-
-// Where locked balls are parked while waiting for multiball
-L.lockSlots = [
-  { x: -7.6, y: 27.4 },
-  { x: -6.7, y: 29.6 }
-];
-
-/* ------------------------------------------------------------ wall polylines */
 
 function mirrorXRaw(x) {
   return 2 * L.centerX - x;
 }
 const mirrorX = mirrorXRaw;
 
-// Left outer wall down into the outlane and drain funnel
+// Two pop bumpers flanking the castle corridor
+L.bumpers = [
+  { x: -4.4, y: 23.8 },
+  { x: 2.0, y: 23.8 }
+];
+
+/**
+ * P-O-K-A-L drop targets, split into two angled banks either side of the
+ * castle corridor: P-O-K climbs up the left, A-L mirrors on the right.
+ * `a` is the bank angle in playfield radians.
+ */
+const bankA = Math.atan2(3.6, 3.2); // ~48°
+L.targets = [
+  { letter: 'P', x: -5.37, y: 14.8, half: 0.55, a: bankA },
+  { letter: 'O', x: -4.3, y: 16.0, half: 0.55, a: bankA },
+  { letter: 'K', x: -3.23, y: 17.2, half: 0.55, a: bankA },
+  { letter: 'A', x: 1.8, y: 17.13, half: 0.55, a: -bankA },
+  { letter: 'L', x: 3.0, y: 15.78, half: 0.55, a: -bankA }
+];
+
+/* ------------------------------------------------------------------- castle */
+
+L.castle = {
+  // Gate the ball bashes open (a collider while closed)
+  gate: [-2.45, 28.45, 0.05, 28.45],
+  towers: [
+    { x: -2.95, y: 28.5, r: 0.62 },
+    { x: 0.55, y: 28.5, r: 0.62 }
+  ],
+  // Battlement walls running out from the towers
+  leftWall: [
+    [-5.2, 26.4],
+    [-3.7, 28.15],
+    [-2.55, 28.55]
+  ],
+  rightWall: [
+    [0.15, 28.55],
+    [1.3, 28.15],
+    [2.8, 26.4]
+  ]
+};
+
+// The trophy stands in the castle courtyard, behind the gate
+L.jackpot = { x: L.centerX, y: 30.4, r: 1.0 };
+
+// Locked balls are parked in the courtyard corners, visible through the
+// gate but clear of the trophy's collision reach — a released ball must not
+// collect a jackpot it never earned.
+L.lockSlots = [
+  { x: -2.5, y: 29.1 },
+  { x: 0.3, y: 29.1 }
+];
+
+/* ------------------------------------------------------------------- ramps */
+
+/**
+ * Wireform ramps. A ball crossing the capture sensor fast enough is lifted
+ * out of the 2D simulation and carried along `path` ([x, y, height] in
+ * playfield coordinates), then dropped back in at the far end. Left ramp
+ * feeds the right inlane and vice versa, Medieval Madness style.
+ */
+L.ramps = {
+  left: {
+    capture: [-7.5, 22.8, -6.35, 22.8],
+    minVy: 6.0,
+    exit: { x: 3.73, y: 12.2, vy: -4 },
+    path: [
+      [-6.9, 22.8, 0.5],
+      [-6.7, 26.0, 1.9],
+      [-5.6, 29.5, 3.1],
+      [-3.2, 32.0, 3.7],
+      [-0.5, 32.8, 3.9],
+      [2.2, 31.0, 3.4],
+      [4.3, 26.5, 2.5],
+      [4.9, 20.0, 1.6],
+      [4.4, 14.5, 0.9],
+      [3.73, 12.4, 0.55]
+    ]
+  },
+  right: {
+    capture: [4.4, 25.5, 6.3, 25.5],
+    minVy: 6.5,
+    exit: { x: -6.2, y: 11.8, vy: -4 },
+    path: [
+      [5.5, 25.5, 0.5],
+      [5.9, 29.0, 2.0],
+      [4.6, 32.6, 3.3],
+      [1.5, 34.6, 4.1],
+      [-2.0, 34.9, 4.3],
+      [-5.2, 33.4, 3.8],
+      [-7.6, 29.5, 2.8],
+      [-8.5, 24.0, 1.9],
+      [-8.2, 17.0, 1.1],
+      [-7.2, 13.4, 0.7],
+      [-6.2, 11.6, 0.5]
+    ]
+  }
+};
+
+/* ------------------------------------------------------------ wall polylines */
+
+// Left outer wall: flares out below the dome for the ramp lane, straightens
+// for the outlane, then funnels into the drain.
 L.leftWall = [
   [-L.outerX, L.domeY],
+  [-L.flareX, 27.5],
+  [-L.flareX, 13.2],
+  [-L.outerX, 10.8],
   [-L.outerX, 9],
   [-7.8, 4.2],
   [-3.3, -1.4]
@@ -111,36 +178,97 @@ L.rightWall = [
   [mirrorX(-3.3), -1.4]
 ];
 
-// Slingshot faces — the ball is kicked along the face normal, toward centre
-L.leftSling = [
-  [-7.6, L.slingTopY],
-  [-5.0, L.slingBotY]
+// Divider between the left orbit (outside) and the left ramp lane (inside)
+L.leftDivider = [
+  [-7.75, 14.8],
+  [-7.75, 23.8]
 ];
-L.rightSling = [
-  [mirrorX(-7.6), L.slingTopY],
-  [mirrorX(-5.0), L.slingBotY]
+// Inner wall of the ramp lane, keeping it clear of the bumper area
+L.leftRampInner = [
+  [-6.1, 18.6],
+  [-6.1, 22.8]
 ];
 
-// Inlane/outlane dividers, guiding returns onto the flippers
-L.leftGuide = [
-  [-5.0, L.slingBotY],
-  [-5.5, 5.2]
+/**
+ * One-way return gates at the bottom of each orbit: a FAST-falling ball (an
+ * orbit return) rides the wire down into the inlane, while ascending shots
+ * and slow dribbles swing straight through — dribbles then take their
+ * chances with the outlane, exactly like a real flap. Nothing can rest on
+ * the wire, because a resting ball no longer matches the speed filter.
+ */
+L.leftReturnGate = [
+  [-9.35, 14.4],
+  [-8.5, 13.4],
+  [-7.4, 12.85],
+  [-6.6, 12.5]
 ];
-L.rightGuide = [
-  [mirrorX(-5.0), L.slingBotY],
-  [mirrorX(-5.5), 5.2]
+L.rightReturnGate = [
+  [6.55, 14.4],
+  [5.7, 13.4],
+  [4.6, 12.85],
+  [4.2, 12.5]
 ];
+
+/**
+ * Inlane/outlane guide rails: the long arm walls off the outlane, the hook at
+ * the bottom curls around and drops the ball onto the flipper heel. Outside
+ * the rail the outlane runs straight into the drain — a real side exit.
+ */
+L.leftRail = [
+  [-7.08, 12.55],
+  [-7.08, 8.7],
+  [-6.65, 7.55],
+  [-5.95, 7.15],
+  [-5.3, 7.45]
+];
+L.rightRail = L.leftRail.map(([x, y]) => [mirrorX(x), y]);
+
+/**
+ * Slingshot triangles: T top, BO bottom-outer, BI bottom-inner.
+ * T→BI is the kicker face; the other two edges are plain walls.
+ */
+L.leftSlingPts = { T: [-4.95, 11.7], BO: [-4.72, 9.45], BI: [-3.75, 9.0] };
+L.rightSlingPts = {
+  T: [mirrorX(-4.95), 11.7],
+  BO: [mirrorX(-4.72), 9.45],
+  BI: [mirrorX(-3.75), 9.0]
+};
+// Kept as simple 2-point faces for the mesh flash lookup
+L.leftSling = [L.leftSlingPts.T, L.leftSlingPts.BI];
+L.rightSling = [L.rightSlingPts.T, L.rightSlingPts.BI];
+
+// Rubber posts protecting bank ends and the ramp-lane mouth
+L.posts = [
+  { x: -5.85, y: 14.2, r: 0.28 },
+  { x: -2.75, y: 17.9, r: 0.28 },
+  { x: 1.25, y: 17.9, r: 0.28 },
+  { x: 3.45, y: 14.6, r: 0.28 },
+  { x: -7.75, y: 24.05, r: 0.3 }
+];
+
+// Scoring switches: invisible sensors the ball rolls through.
+L.sensors = {
+  leftOrbit: [-9.35, 18, -8.0, 18],
+  rightOrbit: [4.6, 27.2, 6.5, 27.2],
+  leftRamp: L.ramps.left.capture,
+  rightRamp: L.ramps.right.capture,
+  inlaneLeft: [-6.9, 10.2, -5.4, 10.2],
+  inlaneRight: [mirrorXRaw(-5.4), 10.2, mirrorXRaw(-6.9), 10.2],
+  outLeft: [-8.85, 9.2, -7.35, 9.2],
+  outRight: [mirrorXRaw(-7.35), 9.2, mirrorXRaw(-8.85), 9.2]
+};
 
 /* ------------------------------------------------------------------ colliders */
 
 /**
  * Builds every collider and flipper into `world`.
  * `hooks` receives gameplay events: onBumper, onSling, onTarget, onJackpot,
- * onWall, onOrbit.
+ * onGate, onWall, onSensor, onFlipper.
  */
 export function buildColliders(world, hooks = {}) {
-  const refs = { targets: [], bumpers: [], flippers: {}, orbitGates: [] };
+  const refs = { targets: [], bumpers: [], flippers: {} };
   const wallOpts = { radius: 0.3, restitution: 0.4, friction: 0.05 };
+  const railOpts = { radius: 0.22, restitution: 0.42, friction: 0.04 };
   const hitWall = (v) => hooks.onWall && hooks.onWall(v);
 
   // Outer shell
@@ -160,19 +288,44 @@ export function buildColliders(world, hooks = {}) {
     segment(L.laneX, L.laneBottomY, L.outerX, L.laneBottomY, { ...wallOpts, restitution: 0.15 })
   );
 
-  // Slingshots — strong kick, awards points
+  // Orbit/ramp divider and ramp lane inner wall
+  world.add(chain(L.leftDivider, railOpts));
+  world.add(chain(L.leftRampInner, railOpts));
+
+  // Inlane/outlane guide rails (the hook returns)
+  world.add(chain(L.leftRail, railOpts));
+  world.add(chain(L.rightRail, railOpts));
+
+  // One-way orbit return gates: solid only for fast-falling balls. Once the
+  // wire catches a ball it keeps carrying it (rideGate) until the tip drops
+  // it into the inlane — without the hysteresis the first impact would kill
+  // the fall speed and release the ball mid-wire, over the outlane.
+  const gateFilter = (b) => {
+    if (b.vy < -6) {
+      b.rideGate = true;
+      return true;
+    }
+    if (b.rideGate && b.vy <= 1 && b.y > 12.2) return true;
+    b.rideGate = false;
+    return false;
+  };
+  const downOnly = { radius: 0.24, restitution: 0.16, friction: 0.1, filter: gateFilter };
+  world.add(chain(L.leftReturnGate, downOnly));
+  world.add(chain(L.rightReturnGate, downOnly));
+
+  // Slingshots: kicker face plus two plain edges
   const slingOpts = (side) => ({
-    radius: 0.32,
+    radius: 0.28,
     restitution: 0.62,
     kick: 13,
+    kickMin: 2.5,
     onHit: (v) => hooks.onSling && hooks.onSling(side, v)
   });
-  world.add(chain(L.leftSling, slingOpts('left')));
-  world.add(chain(L.rightSling, slingOpts('right')));
-
-  // Return guides
-  world.add(chain(L.leftGuide, wallOpts));
-  world.add(chain(L.rightGuide, wallOpts));
+  [['left', L.leftSlingPts], ['right', L.rightSlingPts]].forEach(([side, P]) => {
+    world.add(segment(P.T[0], P.T[1], P.BI[0], P.BI[1], slingOpts(side)));
+    world.add(segment(P.T[0], P.T[1], P.BO[0], P.BO[1], { ...railOpts, radius: 0.28 }));
+    world.add(segment(P.BO[0], P.BO[1], P.BI[0], P.BI[1], { ...railOpts, radius: 0.28 }));
+  });
 
   // Pop bumpers
   L.bumpers.forEach((b, i) => {
@@ -186,9 +339,11 @@ export function buildColliders(world, hooks = {}) {
     refs.bumpers.push(c);
   });
 
-  // P-O-K-A-L drop targets
+  // P-O-K / A-L drop targets (angled banks)
   L.targets.forEach((t, i) => {
-    const c = segment(t.x - t.half, t.y, t.x + t.half, t.y, {
+    const dx = Math.cos(t.a) * t.half;
+    const dy = Math.sin(t.a) * t.half;
+    const c = segment(t.x - dx, t.y - dy, t.x + dx, t.y + dy, {
       radius: 0.26,
       restitution: 0.34,
       id: `target${i}`,
@@ -198,7 +353,22 @@ export function buildColliders(world, hooks = {}) {
     refs.targets.push(c);
   });
 
-  // Jackpot trophy
+  // Castle: battlement walls, towers, bashable gate, trophy in the courtyard
+  world.add(chain(L.castle.leftWall, wallOpts));
+  world.add(chain(L.castle.rightWall, wallOpts));
+  L.castle.towers.forEach((t) => {
+    world.add(circle(t.x, t.y, t.r, { restitution: 0.5, onHit: hitWall }));
+  });
+  const [gax, gay, gbx, gby] = L.castle.gate;
+  refs.gate = world.add(
+    segment(gax, gay, gbx, gby, {
+      radius: 0.3,
+      restitution: 0.45,
+      id: 'gate',
+      onHit: (v, b) => hooks.onGate && hooks.onGate(v, b)
+    })
+  );
+
   const jack = circle(L.jackpot.x, L.jackpot.y, L.jackpot.r, {
     restitution: 0.55,
     kick: 8,
@@ -208,7 +378,7 @@ export function buildColliders(world, hooks = {}) {
   world.add(jack);
   refs.jackpot = jack;
 
-  // Decorative posts
+  // Rubber posts
   L.posts.forEach((p) => {
     world.add(circle(p.x, p.y, p.r, { restitution: 0.55, onHit: hitWall }));
   });
@@ -256,8 +426,8 @@ export function buildColliders(world, hooks = {}) {
 
 const TEX_W = 1024;
 const TEX_H = 2048;
-// Region of playfield space the texture covers
-const ART = { x0: -L.outerX - 0.6, x1: L.outerX + 0.6, y0: -2, y1: 42 };
+// Region of playfield space the texture covers (wider on the left for the flare)
+const ART = { x0: -L.flareX - 0.7, x1: L.outerX + 0.6, y0: -2, y1: 42 };
 
 const toU = (x) => ((x - ART.x0) / (ART.x1 - ART.x0)) * TEX_W;
 const toV = (y) => TEX_H - ((y - ART.y0) / (ART.y1 - ART.y0)) * TEX_H;
@@ -274,8 +444,6 @@ export function createPlayfieldCanvas(participants = [], logo = null) {
 
   const GOLD = '#f2c14e';
   const GOLD_DIM = 'rgba(242,193,78,.32)';
-  // Everything on the playfield lines up on its centre line; only the dome
-  // decoration follows the dome, which sits on the table's centre instead.
   const cx = L.centerX;
   const unitsX = (u) => (u / (ART.x1 - ART.x0)) * TEX_W;
   const unitsY = (u) => (u / (ART.y1 - ART.y0)) * TEX_H;
@@ -295,7 +463,7 @@ export function createPlayfieldCanvas(participants = [], logo = null) {
     g.fillStyle = grad;
     g.fillRect(0, 0, TEX_W, TEX_H);
   };
-  pool(cx, 28, 430, 'rgba(124,140,248,.20)');
+  pool(cx, 29, 430, 'rgba(124,140,248,.20)');
   pool(cx, 13.2, 400, 'rgba(242,193,78,.13)');
   pool(cx, 7, 300, 'rgba(242,193,78,.10)');
 
@@ -308,56 +476,108 @@ export function createPlayfieldCanvas(participants = [], logo = null) {
     g.stroke();
   }
 
-  /* ---- Orbit lanes either side of the target bank ---- */
-  g.strokeStyle = 'rgba(124,140,248,.28)';
-  g.lineWidth = 5;
-  [-7.6, L.laneX - 1.2].forEach((x) => {
+  /* ---- Castle forecourt: cobblestone half-rings before the gate ---- */
+  g.strokeStyle = 'rgba(180,190,220,.16)';
+  g.lineWidth = 3;
+  for (let r = 1.6; r <= 4.6; r += 0.75) {
     g.beginPath();
-    g.moveTo(toU(x), toV(13.5));
-    g.lineTo(toU(x), toV(24.5));
+    g.ellipse(toU(cx), toV(28.4), unitsX(r), unitsY(r), 0, 0.15 * Math.PI, 0.85 * Math.PI);
     g.stroke();
-  });
-
-  /* ---- Jackpot, high enough that the trophy doesn't cover it ---- */
+  }
+  g.fillStyle = 'rgba(220,228,255,.5)';
+  g.font = '700 24px "Space Grotesk", Inter, sans-serif';
   g.textAlign = 'center';
   g.textBaseline = 'middle';
-  g.fillStyle = GOLD;
-  g.font = '700 26px "Space Grotesk", Inter, sans-serif';
-  g.letterSpacing = '8px';
-  g.shadowColor = 'rgba(242,193,78,.6)';
-  g.shadowBlur = 18;
-  g.fillText('JACKPOT', toU(cx), toV(36.2));
+  g.letterSpacing = '7px';
+  g.shadowColor = 'rgba(124,140,248,.7)';
+  g.shadowBlur = 14;
+  g.fillText('BORGEN', toU(cx), toV(25.0));
   g.shadowBlur = 0;
   g.letterSpacing = '0px';
 
-  g.strokeStyle = GOLD;
-  g.lineWidth = 4;
-  g.setLineDash([14, 10]);
+  /* ---- Castle corridor arrows ---- */
+  g.fillStyle = 'rgba(124,140,248,.35)';
+  for (let i = 0; i < 3; i++) {
+    const y = 19.6 + i * 1.6;
+    g.beginPath();
+    g.moveTo(toU(cx - 0.6), toV(y));
+    g.lineTo(toU(cx + 0.6), toV(y));
+    g.lineTo(toU(cx), toV(y + 0.85));
+    g.closePath();
+    g.fill();
+  }
+
+  /* ---- Orbit + ramp lane guides ---- */
+  g.strokeStyle = 'rgba(124,140,248,.28)';
+  g.lineWidth = 5;
   g.beginPath();
-  g.ellipse(toU(L.jackpot.x), toV(L.jackpot.y), unitsX(2.05), unitsY(2.05), 0, 0, Math.PI * 2);
+  g.moveTo(toU(-8.65), toV(13.5));
+  g.lineTo(toU(-8.65), toV(24.5));
   g.stroke();
-  g.setLineDash([]);
-
-  /* ---- Target bank ---- */
-  g.fillStyle = 'rgba(255,255,255,.34)';
-  g.font = '700 23px Inter, sans-serif';
-  g.letterSpacing = '6px';
-  g.fillText('SLÅ NER ALLA FEM', toU(cx), toV(21.3));
-  g.letterSpacing = '0px';
-
-  // A letter under each target so the bank reads as P-O-K-A-L on the table
-  g.font = '700 34px "Space Grotesk", Inter, sans-serif';
-  L.targets.forEach((t) => {
-    g.fillStyle = 'rgba(242,193,78,.5)';
-    g.fillText(t.letter, toU(t.x), toV(17.5));
+  g.beginPath();
+  g.moveTo(toU(5.55), toV(13.5));
+  g.lineTo(toU(5.55), toV(25.5));
+  g.stroke();
+  // Ramp lane arrows (gold, pointing up)
+  g.fillStyle = 'rgba(242,193,78,.4)';
+  [[-6.9, 16.2], [-6.9, 18.4], [-6.9, 20.6]].forEach(([x, y]) => {
+    g.beginPath();
+    g.moveTo(toU(x - 0.45), toV(y));
+    g.lineTo(toU(x + 0.45), toV(y));
+    g.lineTo(toU(x), toV(y + 0.8));
+    g.closePath();
+    g.fill();
   });
+  g.save();
+  g.translate(toU(-8.65), toV(19.5));
+  g.rotate(-Math.PI / 2);
+  g.fillStyle = 'rgba(124,140,248,.5)';
+  g.font = '700 20px Inter, sans-serif';
+  g.letterSpacing = '6px';
+  g.fillText('ORBIT', 0, 0);
+  g.restore();
+  g.save();
+  g.translate(toU(-6.55), toV(19.9));
+  g.rotate(-Math.PI / 2);
+  g.fillStyle = 'rgba(242,193,78,.55)';
+  g.font = '700 20px Inter, sans-serif';
+  g.letterSpacing = '6px';
+  g.fillText('RAMP', 0, 0);
+  g.restore();
+  g.save();
+  g.translate(toU(5.55), toV(20.2));
+  g.rotate(Math.PI / 2);
+  g.fillStyle = 'rgba(124,140,248,.5)';
+  g.font = '700 20px Inter, sans-serif';
+  g.letterSpacing = '6px';
+  g.fillText('ORBIT · RAMP', 0, -14);
+  g.restore();
+
+  /* ---- Target banks: a letter in front of each target's face ---- */
+  g.font = '700 30px "Space Grotesk", Inter, sans-serif';
+  L.targets.forEach((t) => {
+    const off = 1.05;
+    const lx = t.x + Math.sin(t.a) * off;
+    const ly = t.y - Math.cos(t.a) * off;
+    g.fillStyle = 'rgba(242,193,78,.55)';
+    g.fillText(t.letter, toU(lx), toV(ly));
+  });
+  g.fillStyle = 'rgba(255,255,255,.3)';
+  g.font = '700 19px Inter, sans-serif';
+  g.letterSpacing = '4px';
+  g.save();
+  g.translate(toU(-4.9), toV(13.4));
+  g.rotate(-bankA * 0.9);
+  g.fillText('SLÅ NER ALLA FEM', 0, 0);
+  g.restore();
+  g.letterSpacing = '0px';
 
   /* ---- Hero logo, centred in the lower playfield ---- */
   if (logo && logo.width) {
-    const w = 7.8;
+    const w = 6.6;
     const h = (w * logo.height) / logo.width;
     const px = toU(cx - w / 2);
-    const py = toV(13.2 + h / 2);
+    const py = toV(11.9 + h / 2);
     g.save();
     g.globalAlpha = 0.34;
     g.shadowColor = 'rgba(242,193,78,.85)';
@@ -370,37 +590,37 @@ export function createPlayfieldCanvas(participants = [], logo = null) {
   } else {
     g.fillStyle = GOLD;
     g.font = '700 54px "Space Grotesk", Inter, sans-serif';
-    g.fillText('PEKKAS POKAL', toU(cx), toV(13.6));
-    g.fillStyle = 'rgba(255,255,255,.45)';
-    g.font = '600 22px Inter, sans-serif';
-    g.letterSpacing = '8px';
-    g.fillText('FLIPPER · 2025', toU(cx), toV(12.2));
-    g.letterSpacing = '0px';
+    g.fillText('PEKKAS POKAL', toU(cx), toV(12.6));
   }
 
-  /* ---- Inlane arrows pointing at the flippers ---- */
+  /* ---- Inlane / outlane labels ---- */
   g.fillStyle = 'rgba(242,193,78,.30)';
-  [-1, 1].forEach((s) => {
-    const ax = cx + s * 4.3;
-    for (let i = 0; i < 3; i++) {
-      const y = 11.4 - i * 1.25;
+  [[-6.15, 'in'], [3.75, 'in']].forEach(([ax]) => {
+    for (let i = 0; i < 2; i++) {
+      const y = 11.6 - i * 1.2;
       g.beginPath();
-      g.moveTo(toU(ax - 0.55), toV(y));
-      g.lineTo(toU(ax + 0.55), toV(y));
-      g.lineTo(toU(ax), toV(y - 0.72));
+      g.moveTo(toU(ax - 0.45), toV(y));
+      g.lineTo(toU(ax + 0.45), toV(y));
+      g.lineTo(toU(ax), toV(y - 0.65));
       g.closePath();
       g.fill();
     }
   });
+  g.fillStyle = 'rgba(242,109,141,.5)';
+  g.font = '700 19px Inter, sans-serif';
+  g.letterSpacing = '3px';
+  g.fillText('UT', toU(-8.05), toV(10.6));
+  g.fillText('UT', toU(mirrorX(-8.05)), toV(10.6));
+  g.letterSpacing = '0px';
 
   /* ---- Roll of honour down the left rail ---- */
   if (participants.length) {
     g.save();
     g.fillStyle = 'rgba(255,255,255,.15)';
-    g.font = '600 18px Inter, sans-serif';
+    g.font = '600 17px Inter, sans-serif';
     g.textAlign = 'left';
     participants.slice(0, 13).forEach((name, i) => {
-      g.fillText(name.toUpperCase(), toU(-8.78), toV(25.2 - i * 0.92));
+      g.fillText(name.toUpperCase(), toU(-9.55), toV(26.3 - i * 0.92));
     });
     g.restore();
     g.textAlign = 'center';


### PR DESCRIPTION
A full table redesign that gives the board real Medieval Madness anatomy, depth and mechanics.

## BORGEN — the castle
- Stone towers with golden cone roofs and pennant flags, crenellated battlement walls, a gate house with **portcullis and a working drawbridge**.
- The trophy now stands **inside the courtyard behind a bashable gate**: three knocks fell the drawbridge for 9 seconds. A lit lock, a lit multiball jackpot, FISKE and FINALEN also hold the gate open.
- Locked balls are parked in the courtyard, visible through the gate, and **burst out through it when multiball starts**.

## Wireform ramps (real 3D depth)
Two chrome twin-tube habitrails cross the table:
- **Kungsvägen** — a dedicated left ramp lane beside the left orbit (the outer wall flares out to make room). Carries the ball over the castle and drops it in the right inlane.
- **Vallgraven** — a fast shot up the right orbit is captured at the top and crosses over the dome into the left inlane.

A captured ball leaves the 2D simulation and rides the 3D curve, then rejoins at the far end. Ramps score 3 000, chain combos, count as GOKART laps and relight the multiball jackpot.

## Real outlanes — the ball can drain past the flippers
- Inlane/outlane guide rails with hook returns that drop the ball on the flipper heel.
- **One-way return gates** (a new speed-filtered collider with ride hysteresis): fast orbit returns are carried safely into the inlane, slow dribbles fall through and risk the outlane — exactly like a real flap.

## Layout & physics
- The POKAL bank splits into **two angled banks** — P-O-K climbs the left, A-L mirrors on the right — opening a clean castle corridor up the middle.
- Slingshots are proper rubber triangles with glowing kicker faces and a **trigger threshold** (`kickMin`) so grazing balls don't fire them.
- New physics options: per-collider `filter` (one-way gates) and `kickMin`. Smaller ball (0.54) so every lane has honest clearance. Apron over the drain, taller walls, castle forecourt artwork, lane labels (ORBIT/RAMP/UT).
- New SFX: ramp whoosh, gate knocks, drawbridge falling, outlane warning.

## Verification
- **Node harness, 12 suites, all green**: launches never tunnel; outlanes drain; inlanes feed the flipper; orbit returns guided past the outlane; slow dribbles reach the outlane; both banks clearable; ramp capture speed-gated; gate blocks the trophy when closed and admits it when open; ball-ball collisions separate; multiball release escapes the courtyard.
- **Playwright**: gate opens after exactly 3 bashes; ramp riders travel the wireform and land in the opposite inlane; lock → 2-ball multiball with the gate open; the full mode ladder to FINALEN (all five grenar, wizard ×5, extra ball, Skytte order) still passes; **zero console errors**.
- Site-wide smoke test green; ESLint 0 errors. README updated with the new table guide.

Note: this merge also carries #51 (the ruleset) to the live site — its own merge never triggered a deploy run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb)_