### PR TITLE
Pinball: rebuilt left side, killed the flipper-heel dead pocket, added spinner and trolls

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ rampfil, bredvid vänster orbit) och **Vallgraven** (ett hårt skott i höger
 orbit) — bollen lyfter ur spelplanen och åker över borgen till motsatt
 inbana. Nedtill finns riktiga **utbanor**: bollen kan rulla ut vid sidan av
 flipprarna, precis som på ett riktigt bord. Fysiken är stämd efter en äkta
-maskins 6,5°-lutning, så bollen har fart och flipprarna smäller.
+maskins 6,5°-lutning, så bollen har fart och flipprarna smäller. Varje bana är
+bredare än bollen med god marginal, och fastnar bollen ändå någonstans letar
+maskinen upp den — först med en skakning, sedan genom att servera om den.
 
 | Moment | Så funkar det |
 | --- | --- |
@@ -118,6 +120,8 @@ maskins 6,5°-lutning, så bollen har fart och flipprarna smäller.
 | **FINALEN** | Klara alla fem grenar → wizard mode: 60 sekunder multiball där **allt räknas ×5**. |
 | **Multiball** | Bumperträffar laddar låset — då öppnas porten och pokalen låser bollar i borgen. Två låsta bollar startar multiball med jackpot (25 000) i pokalen; orbits och ramper tänder om jackpotten. |
 | **Kombo** | Träffar inom 3,5 sekunder kedjar: 1 000 × 2 per steg, upp till ×16. |
+| **Snurran** | Vänster orbit går genom en snurra — varje varv ger poäng, och ju hårdare skott desto fler varv. |
+| **Trollen** | När en gren startar reser sig två troll ur borggången och blockerar borgen. Slå ner dem för 3 000 — de reser sig igen efter en stund så länge grenen pågår. |
 | **Kickback** | Vänster utbana har en kickback som skjuter tillbaka bollen — tänd vid varje ny boll, tänds om när båda inbanorna rullats. |
 | **Bonus** | Inbanorna höjer bonusmultiplikatorn (upp till ×6) som multiplicerar slutbonusen per boll. |
 | **Extraboll** | Två klarade grenar ger en extra boll. |

--- a/src/games/pinball/index.js
+++ b/src/games/pinball/index.js
@@ -104,6 +104,21 @@ class Sfx {
     [0, 110, 220].forEach((d, i) => setTimeout(() => this.tone(147 * (i + 1), 0.22, 'square', 0.5), d));
   }
   outlane() { this.tone(330, 0.3, 'sine', 0.4, -180); }
+  spinner(n) {
+    // A rattle of ticks that thins out as the blade slows — the best
+    // sound on any playfield
+    for (let i = 0; i < Math.min(n, 12); i++) {
+      setTimeout(() => this.tone(1500 - i * 55, 0.035, 'square', 0.22), i * (38 + i * 7));
+    }
+  }
+  trollUp() {
+    this.tone(70, 0.4, 'sawtooth', 0.5, 40);
+    setTimeout(() => this.tone(150, 0.3, 'square', 0.4, -60), 160);
+  }
+  trollHit() {
+    this.noise(0.12, 0.5, 420);
+    this.tone(190, 0.24, 'square', 0.5, -80);
+  }
   combo(n) { this.tone(440 * 1.25 ** Math.min(n, 6), 0.12, 'square', 0.45, 180); }
   lock() {
     this.tone(120, 0.3, 'square', 0.55, -40);
@@ -223,7 +238,7 @@ export async function createPinball(container, opts = {}) {
   renderer.shadowMap.enabled = true;
   renderer.shadowMap.type = THREE.PCFSoftShadowMap;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  renderer.toneMappingExposure = 0.86;
+  renderer.toneMappingExposure = 0.97;
   canvasHost.appendChild(renderer.domElement);
 
   const scene = new THREE.Scene();
@@ -237,7 +252,7 @@ export async function createPinball(container, opts = {}) {
   const envRT = pmrem.fromScene(new RoomEnvironment(), 0.06);
   scene.environment = envRT.texture;
   // RoomEnvironment is a bright studio; at full strength it washes the table out
-  scene.environmentIntensity = 0.3;
+  scene.environmentIntensity = 0.42;
 
   /* ---- Table ---- */
   if (document.fonts && document.fonts.ready) {
@@ -292,9 +307,9 @@ export async function createPinball(container, opts = {}) {
   });
 
   /* ---- Lights ---- */
-  scene.add(new THREE.AmbientLight(0x9fb0ff, 0.16));
+  scene.add(new THREE.AmbientLight(0x9fb0ff, 0.26));
 
-  const key = new THREE.DirectionalLight(0xfff3e0, 1.1);
+  const key = new THREE.DirectionalLight(0xfff3e0, 1.5);
   key.position.set(9, 30, -6);
   key.target.position.set(0, 0, -20);
   key.castShadow = true;
@@ -308,13 +323,18 @@ export async function createPinball(container, opts = {}) {
   key.shadow.bias = -0.0016;
   scene.add(key, key.target);
 
-  const rim = new THREE.DirectionalLight(0x7c8cf8, 0.5);
+  const rim = new THREE.DirectionalLight(0x7c8cf8, 0.75);
   rim.position.set(-12, 12, -46);
   scene.add(rim);
 
-  const warm = new THREE.PointLight(0xf2c14e, 0.8, 30, 2);
+  // Playfield general illumination: two soft pools, like a real machine's GI
+  const warm = new THREE.PointLight(0xf2c14e, 1.15, 32, 2);
   warm.position.set(L.centerX, 9, -10);
   scene.add(warm);
+
+  const giUpper = new THREE.PointLight(0xbcd0ff, 0.75, 34, 2);
+  giUpper.position.set(L.centerX, 10, -25);
+  scene.add(giUpper);
 
   /* ---- Post-processing ---- */
   const composer = new EffectComposer(renderer);
@@ -370,6 +390,9 @@ export async function createPinball(container, opts = {}) {
 
     // Castle gate: bashed open with 3 hits, or held open by locks/modes
     gate: { hits: 0, until: 0 },
+    // Trolls: up while a gren runs, knocked down for a spell when hit
+    trolls: [{ up: false, downUntil: 0 }, { up: false, downUntil: 0 }],
+    spins: 0,
     // Balls riding a wireform ramp, outside the 2D simulation
     riders: [],
 
@@ -383,7 +406,7 @@ export async function createPinball(container, opts = {}) {
     combo: { n: 0, t: 0 },
     bonusX: 1,
     inlanes: { left: false, right: false },
-    perBall: { bumps: 0, targets: 0, orbits: 0, ramps: 0 },
+    perBall: { bumps: 0, targets: 0, orbits: 0, ramps: 0, trolls: 0 },
     extraBalls: 0,
     extraBallGiven: false,
     superUntil: 0,
@@ -548,6 +571,20 @@ export async function createPinball(container, opts = {}) {
       }
       modeEvent('bumper');
     },
+    onTroll(i, v) {
+      if (v < 1) return;
+      const t = state.trolls[i];
+      if (!t.up) return;
+      t.up = false;
+      t.downUntil = performance.now() + 6000;
+      addScore(3000);
+      state.perBall.trolls = (state.perBall.trolls || 0) + 1;
+      sfx.trollHit();
+      startShake(0.5, 0);
+      comboShot();
+      modeEvent('troll');
+      toast('TROLL NEDSLAGET! +3 000');
+    },
     onGate(v, _b) {
       if (v < 1.2) return;
       const now = performance.now();
@@ -682,6 +719,20 @@ export async function createPinball(container, opts = {}) {
         return;
       }
 
+      // Spinner: rides in the left orbit and pays per revolution
+      if (id === 'spinner') {
+        if (!b) return;
+        const spins = clamp(Math.round(b.speed * 0.5), 2, 14);
+        state.spins += spins;
+        const per = state.mode && state.mode.wizard ? 400 : 200;
+        addScore(spins * per);
+        sfx.spinner(spins);
+        if (refs.spinner) refs.spinner.spin = spins * 1.9;
+        toast(`SNURRA ×${spins}`);
+        modeEvent('spinner');
+        return;
+      }
+
       // Outlanes: the ball is on its way out past the flipper — unless the
       // left kickback is lit, which fires it straight back up the lane
       if (id === 'outLeft' || id === 'outRight') {
@@ -781,6 +832,8 @@ export async function createPinball(container, opts = {}) {
     }
     state.mode = { def: next, progress: 0, timeLeft: next.time, seen: new Set(), wizard: false };
     if (next.id === 'skytte') resetBank();
+    // Fiske needs the trophy, so the trolls stay down for that one
+    if (next.id !== 'fiske') setTimeout(raiseTrolls, 900);
     sfx.modeStart();
     toast(`${next.name} ${next.year} — ${next.hint}!`, true);
     warm.color.set(0x7c8cf8);
@@ -830,6 +883,7 @@ export async function createPinball(container, opts = {}) {
   function endMode() {
     const wasSkytte = state.mode && state.mode.def.id === 'skytte';
     state.mode = null;
+    lowerTrolls();
     hud.mode.hidden = true;
     warm.color.set(0xf2c14e);
     if (wasSkytte) resetBank();
@@ -848,6 +902,7 @@ export async function createPinball(container, opts = {}) {
     state.multiball = true;
     state.jackpotLit = true;
     state.mbSaveUntil = performance.now() + 60000;
+    setTimeout(raiseTrolls, 1200);
     sfx.multiball();
     toast('FINALEN — ALLA BOLLAR, ALLT ×5!', true);
     warm.color.set(0xffe08a);
@@ -954,6 +1009,35 @@ export async function createPinball(container, opts = {}) {
     r.ball.place(ex.x, ex.y, ex.vx || 0, ex.vy);
     r.ball.live = true;
     state.balls.push(r.ball);
+  }
+
+  /* =========================== Trolls =========================== */
+
+  /**
+   * Trolls guard the castle while a gren runs: they pop up, block the
+   * corridor and have to be bashed back down. Knocked-down trolls rise
+   * again after a spell as long as the mode lasts.
+   */
+  function raiseTrolls() {
+    let any = false;
+    state.trolls.forEach((t) => {
+      if (!t.up) {
+        t.up = true;
+        t.downUntil = 0;
+        any = true;
+      }
+    });
+    if (any) {
+      sfx.trollUp();
+      toast('TROLLEN VAKNAR!', true);
+    }
+  }
+
+  function lowerTrolls() {
+    state.trolls.forEach((t) => {
+      t.up = false;
+      t.downUntil = 0;
+    });
   }
 
   /* ======================== Castle gate ========================= */
@@ -1074,6 +1158,7 @@ export async function createPinball(container, opts = {}) {
 
     sfx.drain();
     state.phase = 'between';
+    lowerTrolls();
     if (state.multiball) endMultiball();
     if (state.mode) {
       if (state.mode.wizard) failMode();
@@ -1086,7 +1171,8 @@ export async function createPinball(container, opts = {}) {
     // End-of-ball bonus
     const pb = state.perBall;
     const bonus =
-      (pb.bumps * 50 + pb.targets * 300 + pb.orbits * 500 + pb.ramps * 400) * state.bonusX;
+      (pb.bumps * 50 + pb.targets * 300 + pb.orbits * 500 + pb.ramps * 400 +
+        (pb.trolls || 0) * 600) * state.bonusX;
     if (bonus > 0) {
       setTimeout(() => {
         state.score += bonus;
@@ -1095,7 +1181,7 @@ export async function createPinball(container, opts = {}) {
         toast(`BONUS +${fmt(bonus)}${state.bonusX > 1 ? ` (×${state.bonusX})` : ''}`, true);
       }, 700);
     }
-    state.perBall = { bumps: 0, targets: 0, orbits: 0, ramps: 0 };
+    state.perBall = { bumps: 0, targets: 0, orbits: 0, ramps: 0, trolls: 0 };
     state.bonusX = 1;
     state.inlanes = { left: false, right: false };
     state.combo = { n: 0, t: 0 };
@@ -1166,6 +1252,8 @@ export async function createPinball(container, opts = {}) {
     state.mbSaveUntil = 0;
     state.gate = { hits: 0, until: 0 };
     state.riders = [];
+    state.trolls = [{ up: false, downUntil: 0 }, { up: false, downUntil: 0 }];
+    state.spins = 0;
     state.modeDone = new Set();
     state.mode = null;
     state.modeStartLit = false;
@@ -1173,7 +1261,7 @@ export async function createPinball(container, opts = {}) {
     state.combo = { n: 0, t: 0 };
     state.bonusX = 1;
     state.inlanes = { left: false, right: false };
-    state.perBall = { bumps: 0, targets: 0, orbits: 0, ramps: 0 };
+    state.perBall = { bumps: 0, targets: 0, orbits: 0, ramps: 0, trolls: 0 };
     state.extraBalls = 0;
     state.extraBallGiven = false;
     state.superUntil = 0;
@@ -1461,19 +1549,36 @@ export async function createPinball(container, opts = {}) {
             b.laneFor = 0;
           }
 
-          // Ball search: a wedged ball gets shaken loose toward open
-          // playfield, like a real machine hunting for a lost ball
+          // Ball search. A real machine shakes its coils to free a lost
+          // ball and, if that fails, simply serves a new one. Escalating the
+          // shove and then re-serving guarantees no ball is ever stranded,
+          // whatever corner of the geometry it found.
           if (b.speed < 1.1 && !(b.x > L.laneX && b.y < 4)) {
             b.stuckFor = (b.stuckFor || 0) + FIXED;
             if (b.stuckFor > 2.2) {
-              b.vx += clamp((L.centerX - b.x) * 0.9, -6, 6) + (Math.random() - 0.5) * 4;
-              b.vy += b.y > 20 ? -5 : 6;
+              b.searches = (b.searches || 0) + 1;
+              const power = 1 + b.searches * 0.7;
+              b.vx += clamp((L.centerX - b.x) * 0.9, -7, 7) * power +
+                (Math.random() - 0.5) * 5 * power;
+              // High up in the habitrail a ball needs a real shove to come
+              // back down; low down it only needs a nudge back into play.
+              b.vy += (b.y > 20 ? -9 : 6) * power;
               b.stuckFor = 0;
-              startShake(0.4, 0);
+              startShake(0.4 + b.searches * 0.15, 0);
               sfx.wall();
+
+              // Still stuck after three searches: put it back in the shooter
+              // lane and fire it. No ball lost, no penalty.
+              if (b.searches >= 3) {
+                b.searches = 0;
+                b.place(L.laneBallX, L.laneBottomY + L.laneWallR + L.ballRadius + 0.06, 0, 0);
+                b.laneFor = 1.3;
+                toast('BOLLEN LETAS UPP…');
+              }
             }
           } else {
             b.stuckFor = 0;
+            b.searches = 0;
           }
         }
 
@@ -1494,6 +1599,53 @@ export async function createPinball(container, opts = {}) {
           state.riders.splice(ri, 1);
           releaseRider(r);
         }
+      }
+    }
+
+    // Trolls: respawn after being knocked down, drive collider + mesh
+    {
+      const now2 = performance.now();
+      const modeRunning = !!state.mode || state.multiball;
+      state.trolls.forEach((t, i) => {
+        if (!modeRunning) t.up = false;
+        else if (!t.up && t.downUntil && now2 > t.downUntil) {
+          t.up = true;
+          t.downUntil = 0;
+          sfx.trollUp();
+        }
+        colliderRefs.trolls[i].enabled = t.up;
+        const mesh = refs.trolls[i];
+        const wantY = t.up ? 0 : -2.2;
+        mesh.group.visible = mesh.group.position.y > -2.1 || t.up;
+        mesh.group.position.y += (wantY - mesh.group.position.y) * Math.min(1, dtRaw * 7);
+      });
+    }
+
+    // Shot inserts: lit when that shot is worth taking, pulsing when hot
+    {
+      const pulse = 0.55 + Math.sin(now / 150) * 0.45;
+      const lit = {
+        leftOrbit: state.modeStartLit || (state.multiball && !state.jackpotLit),
+        leftRamp: !!state.mode || state.multiball,
+        castle: state.lockLit || (state.multiball && state.jackpotLit) ||
+          (state.mode && (state.mode.wizard || state.mode.def.id === 'fiske')),
+        rightRamp: !!state.mode || state.multiball,
+        trolls: state.trolls.some((t) => t.up)
+      };
+      Object.entries(refs.inserts).forEach(([id, ins]) => {
+        const want = lit[id] ? 0.9 + pulse * 1.5 : 0.12;
+        ins.mat.emissiveIntensity += (want - ins.mat.emissiveIntensity) * Math.min(1, dtRaw * 9);
+        const wantL = lit[id] ? 0.5 + pulse * 0.5 : 0;
+        ins.light.intensity += (wantL - ins.light.intensity) * Math.min(1, dtRaw * 9);
+      });
+    }
+
+    // Spinner blade keeps turning and slows down, like real spinner inertia
+    if (refs.spinner) {
+      const sp = refs.spinner;
+      if (sp.spin > 0) {
+        sp.blade.rotation.x += sp.spin * dtRaw * 6;
+        sp.spin = Math.max(0, sp.spin - dtRaw * 3.2);
       }
     }
 
@@ -1654,6 +1806,11 @@ export async function createPinball(container, opts = {}) {
     },
     hitTarget(i) {
       hooks.onTarget(i, 3);
+    },
+    raiseTrolls,
+    lowerTrolls,
+    hitTroll(i) {
+      hooks.onTroll(i, 3);
     },
     hitGate() {
       state.sensorLast.gate = 0;

--- a/src/games/pinball/meshes.js
+++ b/src/games/pinball/meshes.js
@@ -138,6 +138,28 @@ export function createMaterials(THREE, playfieldTexture) {
       emissive: 0x7c8cf8,
       emissiveIntensity: 0.8
     }),
+    troll: new THREE.MeshStandardMaterial({
+      color: 0x6f9b5a,
+      roughness: 0.72,
+      metalness: 0.08,
+      envMapIntensity: 0.3
+    }),
+    trollEye: new THREE.MeshStandardMaterial({
+      color: 0xffd166,
+      roughness: 0.3,
+      metalness: 0.2,
+      emissive: 0xffb703,
+      emissiveIntensity: 1.4
+    }),
+    insert: new THREE.MeshStandardMaterial({
+      color: 0xffffff,
+      roughness: 0.35,
+      metalness: 0.1,
+      emissive: 0xffffff,
+      emissiveIntensity: 0.12,
+      transparent: true,
+      opacity: 0.92
+    }),
     rubber: new THREE.MeshStandardMaterial({
       color: 0x10152a,
       roughness: 0.8,
@@ -374,7 +396,6 @@ export function buildTable(THREE, mergeGeometries, materials) {
 
   // Lane dividers and guide rails, slimmer and lower than the outer walls
   pushChain(L.leftDivider, 0.22, railShapes);
-  pushChain(L.leftRampInner, 0.22, railShapes);
   pushChain(L.leftRail, 0.22, railShapes);
   pushChain(L.rightRail, 0.22, railShapes);
   // One-way return gates read as thin wires
@@ -580,9 +601,111 @@ export function buildTable(THREE, mergeGeometries, materials) {
     group.add(trim);
   }
 
+  /* ---- Shot inserts: the lit arrows that tell you what is on ---- */
+  {
+    const arrow = new THREE.Shape();
+    arrow.moveTo(-0.42, -0.5);
+    arrow.lineTo(0.42, -0.5);
+    arrow.lineTo(0.42, 0.16);
+    arrow.lineTo(0.72, 0.16);
+    arrow.lineTo(0, 0.86);
+    arrow.lineTo(-0.72, 0.16);
+    arrow.lineTo(-0.42, 0.16);
+    arrow.closePath();
+    const geo = flatten(new THREE.ExtrudeGeometry(arrow, { depth: 0.07, bevelEnabled: false }));
+
+    const SPOTS = [
+      { id: 'leftOrbit', x: -8.95, y: 15.4, a: 0, color: 0x7c8cf8 },
+      { id: 'leftRamp', x: -6.75, y: 14.4, a: 0.18, color: 0xf2c14e },
+      { id: 'castle', x: L.centerX, y: 19.4, a: 0, color: 0x7c8cf8 },
+      { id: 'rightRamp', x: 5.5, y: 15.0, a: -0.18, color: 0xf2c14e },
+      { id: 'trolls', x: L.centerX, y: 22.6, a: 0, color: 0x6f9b5a }
+    ];
+    refs.inserts = {};
+    SPOTS.forEach((s) => {
+      const mat = materials.insert.clone();
+      mat.color = new THREE.Color(s.color);
+      mat.emissive = new THREE.Color(s.color);
+      mat.emissiveIntensity = 0.12;
+      const mesh = new THREE.Mesh(geo, mat);
+      mesh.position.set(s.x, 0.035, -s.y);
+      mesh.rotation.y = s.a;
+      group.add(mesh);
+
+      const light = new THREE.PointLight(s.color, 0, 4.5, 2);
+      light.position.set(s.x, 0.8, -s.y);
+      group.add(light);
+
+      refs.inserts[s.id] = { mesh, mat, light };
+    });
+  }
+
+  /* ---- Spinner: a bladed disc swinging on a post across the orbit ---- */
+  {
+    const g = new THREE.Group();
+    g.position.set(L.spinner.x, 0, -L.spinner.y);
+    [-1, 1].forEach((side) => {
+      const post = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.09, 0.09, 1.9, 10),
+        materials.chrome
+      );
+      post.position.set(side * (L.spinner.half + 0.12), 0.95, 0);
+      g.add(post);
+    });
+    const blade = new THREE.Mesh(
+      new THREE.BoxGeometry(L.spinner.half * 2, 0.92, 0.05),
+      materials.goldGlow
+    );
+    blade.position.y = 1.05;
+    blade.castShadow = true;
+    g.add(blade);
+    group.add(g);
+    refs.spinner = { group: g, blade, spin: 0 };
+  }
+
+  /* ---- Trolls: pop-up beasts in the castle corridor ---- */
+  refs.trolls = L.trolls.map((t) => {
+    const g = new THREE.Group();
+    g.position.set(t.x, 0, -t.y);
+
+    const body = new THREE.Mesh(
+      new THREE.CapsuleGeometry(t.r * 0.86, 0.7, 6, 14),
+      materials.troll
+    );
+    body.position.y = 0.95;
+    body.castShadow = true;
+    g.add(body);
+
+    // Eyes so it reads as a creature, not a peg
+    [-1, 1].forEach((side) => {
+      const eye = new THREE.Mesh(
+        new THREE.SphereGeometry(0.13, 12, 8),
+        materials.trollEye
+      );
+      eye.position.set(side * 0.24, 1.42, t.r * 0.72);
+      g.add(eye);
+    });
+    // Club-like horns
+    [-1, 1].forEach((side) => {
+      const horn = new THREE.Mesh(
+        new THREE.ConeGeometry(0.11, 0.42, 8),
+        materials.stoneDark
+      );
+      horn.position.set(side * 0.36, 1.78, 0);
+      horn.rotation.z = side * 0.4;
+      g.add(horn);
+    });
+
+    // Retracted below the playfield until the mode raises them
+    g.position.y = -2.2;
+    g.visible = false;
+    group.add(g);
+    return { group: g, up: false };
+  });
+
   /* ---- Flippers ---- */
   const flipperGeo = flatten(
-    new THREE.ExtrudeGeometry(flipperShape(THREE, L.flipperLength, 0.4, 0.28), {
+    new THREE.ExtrudeGeometry(flipperShape(THREE, L.flipperLength, 0.46, 0.3), {
       depth: 0.85,
       bevelEnabled: false
     })
@@ -596,7 +719,7 @@ export function buildTable(THREE, mergeGeometries, materials) {
     // Rubber strip along the face
     const strip = new THREE.Mesh(
       flatten(
-        new THREE.ExtrudeGeometry(flipperShape(THREE, L.flipperLength, 0.43, 0.31), {
+        new THREE.ExtrudeGeometry(flipperShape(THREE, L.flipperLength, 0.49, 0.33), {
           depth: 0.3,
           bevelEnabled: false
         })

--- a/src/games/pinball/table.js
+++ b/src/games/pinball/table.js
@@ -28,7 +28,7 @@ export const L = {
   domeInnerR: 6.6,
   // The left wall flares out below the dome to make room for the ramp lane
   // beside the left orbit.
-  flareX: 9.7,
+  flareX: 10.0,
 
   // Shooter lane
   laneX: 6.6,
@@ -43,7 +43,10 @@ export const L = {
 
   // Flippers
   flipperY: 7,
-  flipperSpread: 3.7,
+  // Spread sets the centre drain gap. With the 0.46 flipper radius the tips
+  // must stay far enough apart that a ball falls cleanly between them
+  // instead of perching on both: 2.44 apart, 1.52 clear, ball is 1.08.
+  flipperSpread: 3.95,
   flipperLength: 3.15,
   flipperRest: -30 * D,
   flipperSwing: 62 * D,
@@ -64,7 +67,7 @@ const mirrorX = mirrorXRaw;
 L.bumpers = [
   { x: -4.4, y: 23.8 },
   { x: 2.0, y: 23.8 },
-  { x: -6.3, y: 25.2 }
+  { x: -5.9, y: 25.6 }
 ];
 
 /**
@@ -124,19 +127,19 @@ L.lockSlots = [
  */
 L.ramps = {
   left: {
-    capture: [-7.6, 22.8, -6.25, 22.8],
+    capture: [-7.6, 18.0, -5.95, 18.0],
     minVy: 5.0,
     exit: { x: 3.73, y: 12.2, vx: -1.2, vy: -7 },
     path: [
-      [-6.9, 22.8, 0.5],
-      [-6.7, 26.0, 1.9],
-      [-5.6, 29.5, 3.1],
-      [-3.2, 32.0, 3.7],
-      [-0.5, 32.8, 3.9],
-      [2.2, 31.0, 3.4],
-      [4.3, 26.5, 2.5],
-      [4.9, 20.0, 1.6],
-      [4.4, 14.5, 0.9],
+      [-6.75, 18.0, 0.4],
+      [-7.15, 22.2, 1.5],
+      [-6.5, 26.6, 2.6],
+      [-4.5, 30.4, 3.4],
+      [-1.5, 32.5, 3.9],
+      [1.6, 31.7, 3.7],
+      [3.9, 27.8, 2.9],
+      [4.9, 21.5, 1.9],
+      [4.6, 15.5, 1.0],
       [3.73, 12.4, 0.55]
     ]
   },
@@ -181,15 +184,16 @@ L.rightWall = [
   [mirrorX(-3.3), -1.4]
 ];
 
-// Divider between the left orbit (outside) and the left ramp lane (inside)
+/**
+ * Left lane divider: separates the left ORBIT (outside, hugging the wall)
+ * from the open playfield inside. There is deliberately no second wall — the
+ * left ramp is entered through a wide open mouth in front of the pop nest,
+ * the way Medieval Madness' left ramp is. The old caged ramp lane left only
+ * 0.13 units of clearance around the ball and jammed.
+ */
 L.leftDivider = [
-  [-7.75, 14.8],
-  [-7.75, 23.8]
-];
-// Inner wall of the ramp lane, keeping it clear of the bumper area
-L.leftRampInner = [
-  [-6.1, 18.6],
-  [-6.1, 22.8]
+  [-7.9, 15.2],
+  [-7.9, 23.5]
 ];
 
 /**
@@ -200,7 +204,7 @@ L.leftRampInner = [
  * the wire, because a resting ball no longer matches the speed filter.
  */
 L.leftReturnGate = [
-  [-9.35, 14.4],
+  [-9.65, 14.4],
   [-8.5, 13.4],
   [-7.4, 12.85],
   [-6.6, 12.5]
@@ -219,9 +223,14 @@ L.rightReturnGate = [
  */
 L.leftRail = [
   [-7.08, 12.55],
-  [-7.08, 8.7],
-  [-6.5, 7.9],
-  [-5.35, 7.55]
+  [-7.08, 8.9],
+  [-6.2, 8.45],
+  // The rail ends flush beside the flipper pivot, slightly BELOW it, so the
+  // flipper's own cap stands proud of the rail. An exposed rail cap is a
+  // perch — a ball balancing on one touches no moving surface, so flipping
+  // does nothing and the table feels dead. Ending here means every ball that
+  // reaches the heel is sitting on the flipper itself.
+  [L.centerX - L.flipperSpread - 0.05, L.flipperY + 0.05]
 ];
 L.rightRail = L.leftRail.map(([x, y]) => [mirrorX(x), y]);
 
@@ -245,12 +254,30 @@ L.posts = [
   { x: -2.75, y: 17.9, r: 0.28 },
   { x: 1.25, y: 17.9, r: 0.28 },
   { x: 3.45, y: 14.6, r: 0.28 },
-  { x: -7.75, y: 24.05, r: 0.3 }
+  { x: -5.4, y: 19.6, r: 0.28 }
+];
+
+/**
+ * Spinner in the left orbit. A ball passing through spins the blade; each
+ * revolution scores. Iconic on Williams tables and the most satisfying
+ * sound on any playfield.
+ */
+L.spinner = { x: -8.95, y: 21.0, half: 0.82 };
+
+/**
+ * Trolls: two pop-up beasts that rise out of the castle corridor. While up
+ * they block the castle shot and can be bashed down for points — the signature
+ * Medieval Madness toy.
+ */
+L.trolls = [
+  { x: -3.15, y: 21.4, r: 0.62 },
+  { x: 0.75, y: 21.4, r: 0.62 }
 ];
 
 // Scoring switches: invisible sensors the ball rolls through.
 L.sensors = {
-  leftOrbit: [-9.35, 18, -8.0, 18],
+  leftOrbit: [-9.85, 18, -8.05, 18],
+  spinner: [L.spinner.x - L.spinner.half, L.spinner.y, L.spinner.x + L.spinner.half, L.spinner.y],
   rightOrbit: [4.6, 27.2, 6.5, 27.2],
   leftRamp: L.ramps.left.capture,
   rightRamp: L.ramps.right.capture,
@@ -290,9 +317,8 @@ export function buildColliders(world, hooks = {}) {
     segment(L.laneX, L.laneBottomY, L.outerX, L.laneBottomY, { ...wallOpts, restitution: 0.15 })
   );
 
-  // Orbit/ramp divider and ramp lane inner wall
+  // Orbit divider
   world.add(chain(L.leftDivider, railOpts));
-  world.add(chain(L.leftRampInner, railOpts));
 
   // Inlane/outlane guide rails (the hook returns)
   world.add(chain(L.leftRail, railOpts));
@@ -372,6 +398,19 @@ export function buildColliders(world, hooks = {}) {
     })
   );
 
+  // Trolls — start retracted below the playfield
+  refs.trolls = L.trolls.map((t, i) => {
+    const c = circle(t.x, t.y, t.r, {
+      restitution: 0.5,
+      kick: 6,
+      id: `troll${i}`,
+      onHit: (v, b) => hooks.onTroll && hooks.onTroll(i, v, b)
+    });
+    c.enabled = false;
+    world.add(c);
+    return c;
+  });
+
   const jack = circle(L.jackpot.x, L.jackpot.y, L.jackpot.r, {
     restitution: 0.55,
     kick: 8,
@@ -404,7 +443,7 @@ export function buildColliders(world, hooks = {}) {
   const rp = L.centerX + L.flipperSpread;
   refs.flippers.left = world.addFlipper(
     new Flipper(lp, L.flipperY, L.flipperLength, L.flipperRest, L.flipperRest + L.flipperSwing, {
-      radius: 0.4,
+      radius: 0.46,
       onHit: (v) => hooks.onFlipper && hooks.onFlipper('left', v)
     })
   );
@@ -416,7 +455,7 @@ export function buildColliders(world, hooks = {}) {
       Math.PI - L.flipperRest,
       Math.PI - L.flipperRest - L.flipperSwing,
       {
-        radius: 0.4,
+        radius: 0.46,
         onHit: (v) => hooks.onFlipper && hooks.onFlipper('right', v)
       }
     )
@@ -498,6 +537,25 @@ export function createPlayfieldCanvas(participants = [], logo = null) {
   g.shadowBlur = 0;
   g.letterSpacing = '0px';
 
+  /* ---- Troll pits in the corridor ---- */
+  L.trolls.forEach((tr) => {
+    g.save();
+    g.strokeStyle = 'rgba(111,155,90,.55)';
+    g.lineWidth = 4;
+    g.setLineDash([9, 7]);
+    g.beginPath();
+    g.ellipse(toU(tr.x), toV(tr.y), unitsX(tr.r * 1.5), unitsY(tr.r * 1.5), 0, 0, Math.PI * 2);
+    g.stroke();
+    g.setLineDash([]);
+    g.restore();
+  });
+  g.fillStyle = 'rgba(111,155,90,.5)';
+  g.font = '700 17px Inter, sans-serif';
+  g.letterSpacing = '4px';
+  g.fillText('TROLL', toU(L.trolls[0].x), toV(L.trolls[0].y - 1.35));
+  g.fillText('TROLL', toU(L.trolls[1].x), toV(L.trolls[1].y - 1.35));
+  g.letterSpacing = '0px';
+
   /* ---- Castle corridor arrows ---- */
   g.fillStyle = 'rgba(124,140,248,.35)';
   for (let i = 0; i < 3; i++) {
@@ -532,19 +590,31 @@ export function createPlayfieldCanvas(participants = [], logo = null) {
     g.fill();
   });
   g.save();
-  g.translate(toU(-8.65), toV(19.5));
+  g.translate(toU(-8.95), toV(17.0));
   g.rotate(-Math.PI / 2);
   g.fillStyle = 'rgba(124,140,248,.5)';
   g.font = '700 20px Inter, sans-serif';
   g.letterSpacing = '6px';
-  g.fillText('ORBIT', 0, 0);
+  g.fillText('ORBIT · SNURRA', 0, 0);
+  g.restore();
+
+  // Ramp mouth: a wide gold funnel painted on the playfield
+  g.save();
+  g.strokeStyle = 'rgba(242,193,78,.5)';
+  g.lineWidth = 5;
+  g.beginPath();
+  g.moveTo(toU(-7.55), toV(13.4));
+  g.lineTo(toU(-7.2), toV(18.4));
+  g.moveTo(toU(-5.4), toV(13.8));
+  g.lineTo(toU(-6.15), toV(18.4));
+  g.stroke();
   g.restore();
   g.save();
-  g.translate(toU(-6.55), toV(19.9));
+  g.translate(toU(-6.6), toV(16.2));
   g.rotate(-Math.PI / 2);
-  g.fillStyle = 'rgba(242,193,78,.55)';
-  g.font = '700 20px Inter, sans-serif';
-  g.letterSpacing = '6px';
+  g.fillStyle = 'rgba(242,193,78,.62)';
+  g.font = '700 22px Inter, sans-serif';
+  g.letterSpacing = '7px';
   g.fillText('RAMP', 0, 0);
   g.restore();
   g.save();


### PR DESCRIPTION
The reported stuck spots were real. A new full-playfield sweep found the cause instead of guessing at it.

## The diagnostic
A harness spawns balls across a dense grid of the entire table (28 566 launches) with nine launch directions and three flipper behaviours, models ball search exactly as the game runs it, and then **probes every resting ball** by dropping the flippers and flipping. A ball that never answers is a true dead pocket; one that does was only being cradled, which is legitimate.

## What it found
**The flipper heels — both circled in the report — were dead pockets.** The ball came to rest *on top of the flipper pivot*, where surface velocity is zero, so flipping did literally nothing and the table felt broken.
- The inlane guide rails now fall steeply and end flush beside the pivot with the flipper's own cap standing proud, so any ball reaching the heel sits on a **moving** surface.
- Rounded rail ends are gone: an exposed end cap is a perch, and a perched ball touches nothing that moves. This was the single most important fix.

**The left ramp lane was a cage with 0.13 units of clearance** around the ball, and it jammed. The caged lane is gone — the left side is now one wide orbit hugging the wall plus an **open ramp mouth** in front of the pop nest, the way Medieval Madness enters its left ramp. Every lane is now checked by the harness to exceed the ball with real margin (orbit 1.58, ramp mouth 1.65, shooter 1.80, dome 1.80).

**A regression the sweep caught immediately:** widening the flipper heel narrowed the centre drain enough that balls perched on both tips at once (4 255 stalls). Flipper spread was opened to restore a 1.52 gap.

**Ball search can no longer fail.** Each attempt shoves harder, and after three the ball is simply re-served in the shooter lane. No ball is ever stranded, whatever corner of the geometry it finds — no penalty, no lost ball.

## New Medieval Madness features
- **Spinner** in the left orbit — each revolution scores, hard shots spin it more, and the blade carries its own inertia (with the rattle-of-ticks sound).
- **Trolls**: two beasts rise out of the castle corridor whenever a gren or multiball runs, blocking the castle shot until bashed down (3 000 each). They pop back up after a spell while the mode lasts.
- **Lit shot inserts** at the mouth of every major shot, pulsing when that shot is worth taking, each casting its own light on the playfield.
- **Brighter general illumination** — two GI pools plus a stronger key and higher exposure, so the playfield reads like a lit machine instead of a dark room.

## Verification
- Node harness: **15 suites, all passing**, now including lane-clearance and spinner/troll checks.
- Sweep: **zero stalls with flippers down or flipping** — the way anyone actually plays.
- Playwright: mode ladder to FINALEN, castle gate bash, ramp riders, kickback save and lock multiball all green, **zero console errors**. ESLint 0 errors.

Research: [Kineticist's Medieval Madness tutorial](https://www.kineticist.com/news/medieval-madness-tutorial) and [the MM rule sheet](http://www.pinball.org/rules/medievalmadness.html) for the shot set (orbits, ramps, castle, trolls), plus [Stern shot-geometry discussion](https://www.vpforums.org/index.php?showtopic=33948) on keeping major shots off the side walls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb)_