### PR TITLE
Pinball: fix ballooning bumpers, once-per-ball save with lamp, declutter, strategy card

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Att lägga till ett nytt års spel:
 | Flippers | Vänster/höger halva av skärmen (fungerar samtidigt) | ←/→, A/D eller Z/M |
 | Avfyrare | Håll för kraft, släpp för att skjuta | Mellanslag |
 | Nudga | Knappen NUDGA | N |
+| Strategikort | ?-knappen uppe till höger | ? eller Esc för att stänga |
 
 Släpp avfyraren när mätaren står i det turkosa fältet för en **skill shot** —
 och skjut vänster orbit inom tre sekunder för en **super skill shot** (15 000).
@@ -123,6 +124,7 @@ maskinen upp den — först med en skakning, sedan genom att servera om den.
 | **Snurran** | Vänster orbit går genom en snurra — varje varv ger poäng, och ju hårdare skott desto fler varv. |
 | **Trollen** | När en gren startar reser sig två troll ur borggången och blockerar borgen. Slå ner dem för 3 000 — de reser sig igen efter en stund så länge grenen pågår. |
 | **Kickback** | Vänster utbana har en kickback som skjuter tillbaka bollen — tänd vid varje ny boll, tänds om när båda inbanorna rullats. |
+| **Ny boll** | Lampan vid avloppet lyser de första nio sekunderna: dräneras bollen då serveras den om — en gång per boll. |
 | **Bonus** | Inbanorna höjer bonusmultiplikatorn (upp till ×6) som multiplicerar slutbonusen per boll. |
 | **Extraboll** | Två klarade grenar ger en extra boll. |
 

--- a/src/games/pinball/index.js
+++ b/src/games/pinball/index.js
@@ -184,6 +184,27 @@ function buildHud(root) {
       <div class="pb-power"><i class="pb-skill"></i><span id="pb-power-fill"></span></div>
     </div>
 
+    <button class="pb-info" id="pb-info" aria-label="Så spelar du">?</button>
+
+    <div class="pb-help" id="pb-help" hidden>
+      <div class="pb-help-card">
+        <h3>Strategikort</h3>
+        <p class="pb-help-sub">Pekkas Pokal Flipper</p>
+        <ul class="pb-help-list">
+          <li><i style="--c:#f2c14e"></i><b>Ramper</b> Kungsvägen (vänster mynning) och Vallgraven (hårt skott i höger orbit) — kedjar kombos och räknas som varv.</li>
+          <li><i style="--c:#7c8cf8"></i><b>Vänster orbit</b> Snurran ger poäng per varv. Lyser pilen: starta nästa GREN här.</li>
+          <li><i style="--c:#f26d8d"></i><b>P-O-K-A-L</b> Fäll alla fem målen så tänds grenstart i vänster orbit.</li>
+          <li><i style="--c:#8b93ad"></i><b>Borgen</b> Tre smällar på porten fäller vindbryggan. Bumprarna laddar låset — lås två bollar i borgen för MULTIBALL med jackpot på pokalen.</li>
+          <li><i style="--c:#6f9b5a"></i><b>Trollen</b> Vaktar borgen under grenar och multiball. Slå ner dem — 3 000 styck.</li>
+          <li><i style="--c:#f2c14e"></i><b>Ny boll &amp; kickback</b> Lampan vid avloppet lyser de första sekunderna: dräneras bollen då serveras den om, en gång per boll. Vänster utbana har kickback — tänds om via båda inbanorna.</li>
+          <li><i style="--c:#ffd166"></i><b>Finalen</b> Klara alla fem grenar → 60 sekunder multiball där allt räknas ×5.</li>
+        </ul>
+        <p class="pb-help-tip">Skill shot: släpp avfyraren i det turkosa fältet — och skjut vänster orbit inom tre sekunder för SUPER (15 000).</p>
+        <div class="pb-help-keys">Flippers: skärmhalvorna eller ←/→ · Avfyrare: håll &amp; släpp / mellanslag · Nudge: N</div>
+        <button class="pb-btn" id="pb-help-close">Tillbaka till spelet</button>
+      </div>
+    </div>
+
     <button class="pb-mute" id="pb-mute" aria-label="Ljud på/av">
       <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M11 5 6 9H2v6h4l5 4V5Z"/><path class="pb-wave" d="M15.5 8.5a5 5 0 0 1 0 7"/>
@@ -212,7 +233,10 @@ function buildHud(root) {
     nudge: root.querySelector('#pb-nudge'),
     plunger: root.querySelector('#pb-plunger'),
     powerFill: root.querySelector('#pb-power-fill'),
-    mute: root.querySelector('#pb-mute')
+    mute: root.querySelector('#pb-mute'),
+    info: root.querySelector('#pb-info'),
+    help: root.querySelector('#pb-help'),
+    helpClose: root.querySelector('#pb-help-close')
   };
 }
 
@@ -413,6 +437,8 @@ export async function createPinball(container, opts = {}) {
     // Left-outlane kickback: lit at the start of every ball, relit by
     // completing both inlanes
     kickback: true,
+    // Ball save is once per ball: the relaunch does not re-arm it
+    saveUsed: false,
     sensorLast: {}
   };
 
@@ -496,7 +522,14 @@ export async function createPinball(container, opts = {}) {
       light.intensity = strength;
       flashes.push({ light, base, t: 0 });
     }
-    if (obj) obj.scale.multiplyScalar(1.13);
+    // Pop the mesh to a fixed size over its resting scale — never
+    // cumulative. The old multiplyScalar grew the mesh a little on every
+    // hit and nothing shrank it back, which is why bumpers ballooned.
+    if (obj) {
+      if (obj.userData.baseScale === undefined) obj.userData.baseScale = obj.scale.x;
+      obj.scale.setScalar(obj.userData.baseScale * 1.13);
+      flashes.push({ obj, t: 0 });
+    }
   }
 
   /* ---- Gameplay hooks ---- */
@@ -1107,7 +1140,7 @@ export async function createPinball(container, opts = {}) {
     b.vy = 57 + p * 11;
     b.vx = 0;
     state.phase = 'play';
-    state.ballSaveUntil = performance.now() + BALL_SAVE_MS;
+    state.ballSaveUntil = state.saveUsed ? 0 : performance.now() + BALL_SAVE_MS;
     state.superUntil = performance.now() + 3000;
     hud.plunger.hidden = true;
     hud.controls.hidden = false;
@@ -1146,8 +1179,10 @@ export async function createPinball(container, opts = {}) {
 
     // Last ball gone
     if (performance.now() < state.ballSaveUntil) {
+      state.saveUsed = true;
+      state.ballSaveUntil = 0;
       sfx.launch();
-      toast('BOLLRÄDDNING', true);
+      toast('NY BOLL — räddad!', true);
       placeInLane();
       state.power = 0.72;
       setTimeout(() => {
@@ -1188,6 +1223,7 @@ export async function createPinball(container, opts = {}) {
 
     if (state.extraBalls > 0) {
       state.extraBalls--;
+      state.saveUsed = false;
       renderBalls();
       setTimeout(() => {
         sfx.extraBall();
@@ -1202,6 +1238,7 @@ export async function createPinball(container, opts = {}) {
       return;
     }
     state.ballNo++;
+    state.saveUsed = false;
     state.mult = 1;
     hud.mult.textContent = '×1';
     renderBalls();
@@ -1266,6 +1303,7 @@ export async function createPinball(container, opts = {}) {
     state.extraBallGiven = false;
     state.superUntil = 0;
     state.kickback = true;
+    state.saveUsed = false;
     lockMeshes.forEach((m) => (m.visible = false));
     refs.bumpers.forEach((bm) => {
       bm.ring.material.emissiveIntensity = 0.95;
@@ -1286,6 +1324,7 @@ export async function createPinball(container, opts = {}) {
   }
 
   /* ---- Input ---- */
+  let helpOpen = false;
   const pointers = new Map();
   const flipL = colliderRefs.flippers.left;
   const flipR = colliderRefs.flippers.right;
@@ -1312,7 +1351,7 @@ export async function createPinball(container, opts = {}) {
 
   function onPointerDown(e) {
     sfx.resume();
-    if (e.target.closest('.pb-overlay, .pb-mute, .pb-nudge')) return;
+    if (e.target.closest('.pb-overlay, .pb-mute, .pb-nudge, .pb-info, .pb-help')) return;
     canvasHost.setPointerCapture?.(e.pointerId);
 
     if (state.phase === 'launch') {
@@ -1353,6 +1392,11 @@ export async function createPinball(container, opts = {}) {
   function onKeyDown(e) {
     if (e.repeat) return;
     const k = e.key.toLowerCase();
+    if (helpOpen) {
+      if (k === 'escape' || k === ' ') setHelp(false);
+      e.preventDefault();
+      return;
+    }
     if (k === 'arrowleft' || k === 'a' || k === 'z') setFlipper('left', true);
     else if (k === 'arrowright' || k === 'd' || k === 'm') setFlipper('right', true);
     else if (k === ' ') {
@@ -1433,6 +1477,18 @@ export async function createPinball(container, opts = {}) {
     toast('Nudge');
   }
 
+  // The tick keeps updating `last` even while paused, so closing the card
+  // resumes with a tiny dt — no need to reset the clock here.
+  function setHelp(open) {
+    helpOpen = open;
+    hud.help.hidden = !open;
+    if (open) {
+      flipL.pressed = false;
+      flipR.pressed = false;
+      pointers.clear();
+    }
+  }
+
   canvasHost.addEventListener('pointerdown', onPointerDown);
   window.addEventListener('pointerup', onPointerUp);
   window.addEventListener('pointercancel', onPointerUp);
@@ -1440,6 +1496,8 @@ export async function createPinball(container, opts = {}) {
   window.addEventListener('keydown', onKeyDown);
   window.addEventListener('keyup', onKeyUp);
   hud.start.addEventListener('click', startGame);
+  hud.info.addEventListener('click', () => setHelp(!helpOpen));
+  hud.helpClose.addEventListener('click', () => setHelp(false));
   hud.nudge.addEventListener('click', doNudge);
   hud.mute.addEventListener('click', () => {
     sfx.muted = !sfx.muted;
@@ -1512,7 +1570,7 @@ export async function createPinball(container, opts = {}) {
     raf = requestAnimationFrame(tick);
     const dtRaw = Math.min(0.05, (now - last) / 1000);
     last = now;
-    if (!running) return;
+    if (!running || helpOpen) return;
 
     // Plunger charge
     if (state.phase === 'launch' && state.charging) {
@@ -1625,6 +1683,7 @@ export async function createPinball(container, opts = {}) {
     {
       const pulse = 0.55 + Math.sin(now / 150) * 0.45;
       const lit = {
+        save: state.phase === 'play' && performance.now() < state.ballSaveUntil,
         leftOrbit: state.modeStartLit || (state.multiball && !state.jackpotLit),
         leftRamp: !!state.mode || state.multiball,
         castle: state.lockLit || (state.multiball && state.jackpotLit) ||
@@ -1747,6 +1806,14 @@ export async function createPinball(container, opts = {}) {
       } else if (f.mat) {
         f.mat.emissiveIntensity = Math.max(f.base, f.mat.emissiveIntensity - dtRaw * 16);
         if (f.mat.emissiveIntensity <= f.base + 0.01) flashes.splice(i, 1);
+      } else if (f.obj) {
+        const home = f.obj.userData.baseScale;
+        const sc = f.obj.scale.x + (home - f.obj.scale.x) * Math.min(1, dtRaw * 10);
+        f.obj.scale.setScalar(sc);
+        if (Math.abs(sc - home) < 0.004) {
+          f.obj.scale.setScalar(home);
+          flashes.splice(i, 1);
+        }
       }
     }
 

--- a/src/games/pinball/meshes.js
+++ b/src/games/pinball/meshes.js
@@ -615,19 +615,21 @@ export function buildTable(THREE, mergeGeometries, materials) {
     const geo = flatten(new THREE.ExtrudeGeometry(arrow, { depth: 0.07, bevelEnabled: false }));
 
     const SPOTS = [
+      { id: 'save', x: L.centerX, y: 4.5, a: 0, color: 0xf2c14e, disc: true },
       { id: 'leftOrbit', x: -8.95, y: 15.4, a: 0, color: 0x7c8cf8 },
       { id: 'leftRamp', x: -6.75, y: 14.4, a: 0.18, color: 0xf2c14e },
       { id: 'castle', x: L.centerX, y: 19.4, a: 0, color: 0x7c8cf8 },
       { id: 'rightRamp', x: 5.5, y: 15.0, a: -0.18, color: 0xf2c14e },
       { id: 'trolls', x: L.centerX, y: 22.6, a: 0, color: 0x6f9b5a }
     ];
+    const discGeo = new THREE.CylinderGeometry(0.5, 0.5, 0.07, 22);
     refs.inserts = {};
     SPOTS.forEach((s) => {
       const mat = materials.insert.clone();
       mat.color = new THREE.Color(s.color);
       mat.emissive = new THREE.Color(s.color);
       mat.emissiveIntensity = 0.12;
-      const mesh = new THREE.Mesh(geo, mat);
+      const mesh = new THREE.Mesh(s.disc ? discGeo : geo, mat);
       mesh.position.set(s.x, 0.035, -s.y);
       mesh.rotation.y = s.a;
       group.add(mesh);

--- a/src/games/pinball/table.js
+++ b/src/games/pinball/table.js
@@ -478,7 +478,7 @@ const toV = (y) => TEX_H - ((y - ART.y0) / (ART.y1 - ART.y0)) * TEX_H;
  * Draws the playfield art to a canvas. Doing this procedurally keeps the game
  * asset-free while still looking designed rather than bare.
  */
-export function createPlayfieldCanvas(participants = [], logo = null) {
+export function createPlayfieldCanvas(_participants = [], logo = null) {
   const cv = document.createElement('canvas');
   cv.width = TEX_W;
   cv.height = TEX_H;
@@ -556,51 +556,9 @@ export function createPlayfieldCanvas(participants = [], logo = null) {
   g.fillText('TROLL', toU(L.trolls[1].x), toV(L.trolls[1].y - 1.35));
   g.letterSpacing = '0px';
 
-  /* ---- Castle corridor arrows ---- */
-  g.fillStyle = 'rgba(124,140,248,.35)';
-  for (let i = 0; i < 3; i++) {
-    const y = 19.6 + i * 1.6;
-    g.beginPath();
-    g.moveTo(toU(cx - 0.6), toV(y));
-    g.lineTo(toU(cx + 0.6), toV(y));
-    g.lineTo(toU(cx), toV(y + 0.85));
-    g.closePath();
-    g.fill();
-  }
-
-  /* ---- Orbit + ramp lane guides ---- */
-  g.strokeStyle = 'rgba(124,140,248,.28)';
-  g.lineWidth = 5;
-  g.beginPath();
-  g.moveTo(toU(-8.65), toV(13.5));
-  g.lineTo(toU(-8.65), toV(24.5));
-  g.stroke();
-  g.beginPath();
-  g.moveTo(toU(5.55), toV(13.5));
-  g.lineTo(toU(5.55), toV(25.5));
-  g.stroke();
-  // Ramp lane arrows (gold, pointing up)
-  g.fillStyle = 'rgba(242,193,78,.4)';
-  [[-6.9, 16.2], [-6.9, 18.4], [-6.9, 20.6]].forEach(([x, y]) => {
-    g.beginPath();
-    g.moveTo(toU(x - 0.45), toV(y));
-    g.lineTo(toU(x + 0.45), toV(y));
-    g.lineTo(toU(x), toV(y + 0.8));
-    g.closePath();
-    g.fill();
-  });
+  /* ---- Ramp mouth: a quiet gold funnel, no text — the insert lights it ---- */
   g.save();
-  g.translate(toU(-8.95), toV(17.0));
-  g.rotate(-Math.PI / 2);
-  g.fillStyle = 'rgba(124,140,248,.5)';
-  g.font = '700 20px Inter, sans-serif';
-  g.letterSpacing = '6px';
-  g.fillText('ORBIT · SNURRA', 0, 0);
-  g.restore();
-
-  // Ramp mouth: a wide gold funnel painted on the playfield
-  g.save();
-  g.strokeStyle = 'rgba(242,193,78,.5)';
+  g.strokeStyle = 'rgba(242,193,78,.42)';
   g.lineWidth = 5;
   g.beginPath();
   g.moveTo(toU(-7.55), toV(13.4));
@@ -608,22 +566,6 @@ export function createPlayfieldCanvas(participants = [], logo = null) {
   g.moveTo(toU(-5.4), toV(13.8));
   g.lineTo(toU(-6.15), toV(18.4));
   g.stroke();
-  g.restore();
-  g.save();
-  g.translate(toU(-6.6), toV(16.2));
-  g.rotate(-Math.PI / 2);
-  g.fillStyle = 'rgba(242,193,78,.62)';
-  g.font = '700 22px Inter, sans-serif';
-  g.letterSpacing = '7px';
-  g.fillText('RAMP', 0, 0);
-  g.restore();
-  g.save();
-  g.translate(toU(5.55), toV(20.2));
-  g.rotate(Math.PI / 2);
-  g.fillStyle = 'rgba(124,140,248,.5)';
-  g.font = '700 20px Inter, sans-serif';
-  g.letterSpacing = '6px';
-  g.fillText('ORBIT · RAMP', 0, -14);
   g.restore();
 
   /* ---- Target banks: a letter in front of each target's face ---- */
@@ -635,15 +577,6 @@ export function createPlayfieldCanvas(participants = [], logo = null) {
     g.fillStyle = 'rgba(242,193,78,.55)';
     g.fillText(t.letter, toU(lx), toV(ly));
   });
-  g.fillStyle = 'rgba(255,255,255,.3)';
-  g.font = '700 19px Inter, sans-serif';
-  g.letterSpacing = '4px';
-  g.save();
-  g.translate(toU(-4.9), toV(13.4));
-  g.rotate(-bankA * 0.9);
-  g.fillText('SLÅ NER ALLA FEM', 0, 0);
-  g.restore();
-  g.letterSpacing = '0px';
 
   /* ---- Hero logo, centred in the lower playfield ---- */
   if (logo && logo.width) {
@@ -686,37 +619,15 @@ export function createPlayfieldCanvas(participants = [], logo = null) {
   g.fillText('UT', toU(mirrorX(-8.05)), toV(10.6));
   g.letterSpacing = '0px';
 
-  /* ---- Roll of honour down the left rail ---- */
-  if (participants.length) {
-    g.save();
-    g.fillStyle = 'rgba(255,255,255,.15)';
-    g.font = '600 17px Inter, sans-serif';
-    g.textAlign = 'left';
-    participants.slice(0, 13).forEach((name, i) => {
-      g.fillText(name.toUpperCase(), toU(-9.55), toV(26.3 - i * 0.92));
-    });
-    g.restore();
-    g.textAlign = 'center';
-  }
-
   /* ---- Shooter lane ---- */
   g.fillStyle = 'rgba(242,193,78,.09)';
   g.fillRect(toU(L.laneX), toV(L.domeY), toU(L.outerX) - toU(L.laneX), toV(2) - toV(L.domeY));
 
-  g.save();
-  g.translate(toU((L.laneX + L.outerX) / 2), toV(16));
-  g.rotate(-Math.PI / 2);
+  /* ---- Ball-save lamp label, just above the apron ---- */
   g.fillStyle = 'rgba(242,193,78,.5)';
-  g.font = '700 24px Inter, sans-serif';
-  g.letterSpacing = '8px';
-  g.fillText('DRA OCH SLÄPP', 0, 8);
-  g.restore();
-
-  /* ---- Drain ---- */
-  g.fillStyle = 'rgba(242,109,141,.35)';
-  g.font = '700 21px Inter, sans-serif';
-  g.letterSpacing = '5px';
-  g.fillText('UTGÅNG', toU(cx), toV(1.1));
+  g.font = '700 15px Inter, sans-serif';
+  g.letterSpacing = '3px';
+  g.fillText('NY BOLL', toU(cx), toV(3.55));
   g.letterSpacing = '0px';
 
   /* ---- Grain. Built on its own canvas and composited with drawImage:

--- a/src/styles/games.css
+++ b/src/styles/games.css
@@ -732,3 +732,126 @@ body.game-open {
   background: linear-gradient(140deg, #f2c14e, #d99a2b);
   box-shadow: 0 0 10px rgba(242, 193, 78, 0.8);
 }
+
+/* ---- Strategikort (info button + help card) ---- */
+.pb-info {
+  position: absolute;
+  top: max(12px, env(safe-area-inset-top));
+  right: 104px;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  font: 700 16px 'Space Grotesk', Inter, sans-serif;
+  color: rgba(242, 193, 78, 0.9);
+  background: rgba(12, 16, 32, 0.62);
+  border: 1px solid rgba(242, 193, 78, 0.35);
+  backdrop-filter: blur(8px);
+  pointer-events: auto;
+}
+
+.pb-info:active {
+  transform: scale(0.94);
+}
+
+.pb-help {
+  position: absolute;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  background: rgba(5, 7, 15, 0.82);
+  backdrop-filter: blur(10px);
+  pointer-events: auto;
+}
+
+.pb-help[hidden] {
+  display: none;
+}
+
+.pb-help-card {
+  width: min(430px, 100%);
+  max-height: min(86vh, 720px);
+  overflow-y: auto;
+  padding: 22px 22px 18px;
+  border-radius: 18px;
+  background: linear-gradient(165deg, rgba(21, 27, 52, 0.97), rgba(12, 16, 32, 0.97));
+  border: 1px solid rgba(242, 193, 78, 0.35);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.55);
+}
+
+.pb-help-card h3 {
+  margin: 0;
+  font: 700 22px 'Space Grotesk', Inter, sans-serif;
+  color: #f2c14e;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.pb-help-sub {
+  margin: 2px 0 14px;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(220, 226, 250, 0.55);
+}
+
+.pb-help-list {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0;
+  display: grid;
+  gap: 9px;
+}
+
+.pb-help-list li {
+  position: relative;
+  padding-left: 20px;
+  font-size: 13.5px;
+  line-height: 1.45;
+  color: rgba(224, 229, 250, 0.88);
+}
+
+.pb-help-list li b {
+  color: #fff;
+  display: block;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.pb-help-list li i {
+  position: absolute;
+  left: 0;
+  top: 5px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--c, #f2c14e);
+  box-shadow: 0 0 10px var(--c, #f2c14e);
+}
+
+.pb-help-tip {
+  margin: 0 0 10px;
+  padding: 9px 12px;
+  border-radius: 10px;
+  background: rgba(94, 234, 212, 0.09);
+  border: 1px solid rgba(94, 234, 212, 0.25);
+  font-size: 12.5px;
+  color: rgba(190, 244, 230, 0.9);
+}
+
+.pb-help-keys {
+  margin-bottom: 14px;
+  font-size: 11.5px;
+  letter-spacing: 0.03em;
+  color: rgba(220, 226, 250, 0.5);
+}
+
+.pb-help-card .pb-btn {
+  width: 100%;
+}


### PR DESCRIPTION
Four player-reported issues, all fixed and verified.

## Why the bumpers grew
A real bug: `flash()` multiplied the mesh scale by 1.13 on **every hit** and nothing ever shrank it back, so bumper domes — and the castle trophy — inflated hit by hit for the whole game. The pop is now a fixed size over the mesh's remembered resting scale and decays home, never cumulative. Verified with 30 rapid debug hits: bumpers end at exactly their resting size.

## Ball save: once per ball, with a lamp
- The save relaunch previously **re-armed the save window**, so early drains could chain new balls forever. Now the save fires **once per ball** — a fresh ball, an extra ball or a new game re-arms it, the save relaunch does not.
- There is now a **NY BOLL lamp**: a round insert between the flippers, lit and pulsing while the save window is open, exactly like a real machine's shoot-again light. Labeled on the playfield.
- Focused Playwright test: drain inside the window → saved exactly once (`saveUsed` set, window disarmed); second drain → ball over. ✔

## Decluttered playfield
Removed: DRA OCH SLÄPP, SLÅ NER ALLA FEM, the rotated ORBIT/RAMP lane captions, the painted corridor arrows (the lit inserts do that job now), the misaligned lane guide lines, and the roll-of-honour names half-hidden under the wireforms. What remains is functional and aligned: POKAL letters, TROLL pits, UT markers, the ramp funnel, NY BOLL, and the centre logo.

## Strategy card (like a real cabinet's instruction card)
A **? button** beside the mute toggle opens an overlay card: every shot explained with colour-coded bullets (ramps, orbit/spinner, POKAL, castle, trolls, save/kickback, FINALEN), the skill-shot tip and the controls. The simulation pauses while it's open; Esc or the button closes it. Reachable from the title screen and mid-game.

## Verification
Focused save test ✔ · bumper-scale test ✔ · help open/close ✔ · mode ladder to FINALEN ✔ · all 15 physics suites ✔ · zero console errors · ESLint 0 errors. README updated (controls row + Ny boll rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb)_