### PR TITLE
Pinball: ball-save lamp glows green instead of gold

### DIFF
--- a/src/games/pinball/meshes.js
+++ b/src/games/pinball/meshes.js
@@ -615,7 +615,7 @@ export function buildTable(THREE, mergeGeometries, materials) {
     const geo = flatten(new THREE.ExtrudeGeometry(arrow, { depth: 0.07, bevelEnabled: false }));
 
     const SPOTS = [
-      { id: 'save', x: L.centerX, y: 4.5, a: 0, color: 0xf2c14e, disc: true },
+      { id: 'save', x: L.centerX, y: 4.5, a: 0, color: 0x3ddc7b, disc: true },
       { id: 'leftOrbit', x: -8.95, y: 15.4, a: 0, color: 0x7c8cf8 },
       { id: 'leftRamp', x: -6.75, y: 14.4, a: 0.18, color: 0xf2c14e },
       { id: 'castle', x: L.centerX, y: 19.4, a: 0, color: 0x7c8cf8 },

--- a/src/games/pinball/table.js
+++ b/src/games/pinball/table.js
@@ -624,7 +624,7 @@ export function createPlayfieldCanvas(_participants = [], logo = null) {
   g.fillRect(toU(L.laneX), toV(L.domeY), toU(L.outerX) - toU(L.laneX), toV(2) - toV(L.domeY));
 
   /* ---- Ball-save lamp label, just above the apron ---- */
-  g.fillStyle = 'rgba(242,193,78,.5)';
+  g.fillStyle = 'rgba(61,220,123,.55)';
   g.font = '700 15px Inter, sans-serif';
   g.letterSpacing = '3px';
   g.fillText('NY BOLL', toU(cx), toV(3.55));


### PR DESCRIPTION
The NY BOLL insert between the flippers and its playfield label switch from gold to green, so the save light reads at a glance as its own signal instead of blending into the table's gold accents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb)_