### PR TITLE
Sångboken: new tab with the group's songs from the Drive archive

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -37,6 +37,7 @@ module.exports = {
     
     // Achievement system
     ACHIEVEMENT_DEFINITIONS: 'readonly',
+    PEKKAS_SONGS: 'readonly',
     ACHIEVEMENT_CATEGORIES: 'readonly',
     ACHIEVEMENT_RARITIES: 'readonly',
     AchievementHelpers: 'readonly',

--- a/README.md
+++ b/README.md
@@ -74,7 +74,15 @@ Bilden dyker upp automatiskt högst upp på det årets kort i Historik och i
 resultatrutan. Saknas en bild händer ingenting — inget att konfigurera.
 Liggande format och ca 1200 px bredd fungerar bäst.
 
-### 4. Spel
+### 4. Sångboken
+
+Fliken **Sånger** visar föreningens snapsvisor, ramsor och officiella låtar.
+Texterna bor i [`src/data/songs.js`](src/data/songs.js) — lägg till ett nytt
+objekt i listan (id, år, titel, melodi och textrader) så dyker sången upp i
+väljaren automatiskt. En rad kan också vara `{ o: 'originalrad', t:
+'översättning' }` när sången sjungs på ett annat språk, som Cant del Barça.
+
+### 5. Spel
 
 Fliken **Spel** innehåller ett spel per år. 2025 är *Pekkas Pokal Flipper* — ett
 flipperspel i Three.js som byggs helt i webbläsaren (ingen bild- eller

--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@
           <button class="nav-link" data-view="history">Historik</button>
           <button class="nav-link" data-view="achievements">Utmärkelser</button>
           <button class="nav-link" data-view="stats">Statistik</button>
+          <button class="nav-link" data-view="songs">Sånger</button>
           <button class="nav-link" data-view="games">Spel</button>
           <span class="nav-indicator" aria-hidden="true"></span>
         </nav>
@@ -358,6 +359,15 @@
         </div>
       </section>
       <!-- ============ SPEL ============ -->
+      <section id="view-songs" class="view" aria-label="Sånger">
+        <div class="view-head">
+          <h1>Sångboken</h1>
+          <p class="view-sub">Snapsvisor, ramsor och officiella låtar — ur föreningens arkiv.</p>
+        </div>
+        <div class="song-picker" id="song-picker"></div>
+        <article class="card song-sheet" id="song-sheet"></article>
+      </section>
+
       <section id="view-games" class="view" aria-label="Spel">
         <div class="view-head">
           <h1>Spel</h1>
@@ -405,6 +415,10 @@
         <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 20V10M10 20V4M16 20v-7M22 20H2"/></svg>
         <span>Statistik</span>
       </button>
+      <button class="tab-item" data-view="songs" aria-label="Sånger">
+        <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+        <span>Sånger</span>
+      </button>
       <button class="tab-item" data-view="games" aria-label="Spel">
         <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 11h4M8 9v4M15 11h.01M18 13h.01"/><path d="M17.32 6H6.68a4.68 4.68 0 0 0-4.65 4.13l-.87 7A2.5 2.5 0 0 0 3.64 20c1.1 0 2.08-.72 2.4-1.78L6.6 16h10.8l.56 2.22A2.5 2.5 0 0 0 20.36 20a2.5 2.5 0 0 0 2.48-2.87l-.87-7A4.68 4.68 0 0 0 17.32 6Z"/></svg>
         <span>Spel</span>
@@ -437,6 +451,7 @@
 
     <!-- App -->
     <script src="src/data/achievements.js"></script>
+    <script src="src/data/songs.js"></script>
     <script src="src/scripts/achievement-engine.js"></script>
     <script src="src/scripts/app.js"></script>
   </body>

--- a/src/data/songs.js
+++ b/src/data/songs.js
@@ -1,0 +1,117 @@
+/**
+ * Pekkas Pokal — sångboken.
+ *
+ * Samlade snapsvisor, hyllningar och officiella låtar genom åren, hämtade
+ * ur föreningens arkiv (Snapsvisor-mappen på Google Drive: foton av
+ * anteckningar och delade dokument).
+ *
+ * En rad är antingen en sträng eller { o: 'originalrad', t: 'översättning' }
+ * när sången sjungs på ett annat språk.
+ */
+
+const PEKKAS_SONGS = [
+  {
+    id: 'cant-del-barca',
+    year: 2026,
+    title: 'Cant del Barça',
+    subtitle: 'Officiell låt 2026 · Barcelona',
+    melody: 'FC Barcelonas hymn',
+    lines: [
+      { o: 'Tot el camp', t: 'Hela arenan' },
+      { o: 'és un clam', t: 'är ett rop' },
+      { o: 'som la gent blaugrana.', t: 'vi är det blåröda folket.' },
+      { o: 'Tant se val d’on venim', t: 'Det spelar ingen roll varifrån vi kommer' },
+      { o: 'si del sud o del nord', t: 'om från söder eller från norr' },
+      { o: 'ara estem d’acord, estem d’acord', t: 'nu är vi överens, vi är överens' },
+      { o: 'una bandera ens agermana', t: 'en fana gör oss till bröder' },
+      '',
+      { o: 'Blaugrana al vent', t: 'Blårött i vinden' },
+      { o: 'un crit valent', t: 'ett modigt rop' },
+      { o: 'tenim un nom', t: 'vi har ett namn' },
+      { o: 'el sap tothom', t: 'det vet alla' },
+      'Barça, Barça, Barça!'
+    ]
+  },
+  {
+    id: 'vi-drar-till-pekkas',
+    year: 2022,
+    title: 'Vi drar till Pekkas',
+    melody: 'Vi drar till fjällen — Markoolio',
+    lines: [
+      'Vi drar till Pekkas, nån kommer däcka',
+      'Ute och super med jäger och hembränt',
+      'Vi drar till Pekkas, nån kommer däcka',
+      'Trillar i backen av teca-attacken! 🎿🎿'
+    ]
+  },
+  {
+    id: 'gräver-guld',
+    year: 2022,
+    title: 'För alla vi som tävlat i Pekkas',
+    melody: 'När vi gräver guld i USA — GES',
+    lines: [
+      'För alla vi som tävlat i Pekkas',
+      'Festat natten lång',
+      'Övik är vår stad',
+      'Ända från Brébyn till Arnäsvall',
+      '(vi kommer inte ut förrens vi druckit upp det vi har)',
+      'När vi fightas om Pekkas Pokal 🏆🍻'
+    ]
+  },
+  {
+    id: 'vi-alskar-pekkas',
+    year: 2022,
+    title: 'Vi älskar Pekkas',
+    melody: 'Ramsa — sjungs tills grannarna klagar',
+    lines: [
+      'Vi älskar Pekkas Pekkas Pekkas',
+      'Vi älskar Pekkas. WOOP WOOP. 🎶🎉',
+      '',
+      'Vi älskar Pekkas Pekkas Pekkas',
+      'Vi älskar Pekkas. WOOP WOOP. 🎶🎉'
+    ]
+  },
+  {
+    id: 'pekkas-ramsa',
+    year: 2022,
+    title: 'Pekkas ☀️',
+    melody: 'Ramsa',
+    lines: [
+      'Kuken ballen kempehallen',
+      'Pekka Gunilla, Henke mår illa',
+      'Röven håret, största låret',
+      'Pekkas brede, tredje benet!'
+    ]
+  },
+  {
+    id: 'viktor-jones-fylledrang',
+    year: 2021,
+    title: 'Viktor Jones fylledräng',
+    melody: 'Trad. — ur gruppchatten 8 aug 2021',
+    lines: [
+      'Viktor Jones fylledräng',
+      'Fylledräng fylledräng',
+      'Han vaktade sina teqor fem',
+      'Teqor fem teqor fem',
+      'Damerna de kvittra så glada',
+      'Han har allt en man skall hava',
+      'Mustasch hockeyfrilla å,',
+      'en betongsugga som e blå'
+    ]
+  },
+  {
+    id: 'pekkas-go-west',
+    year: 2021,
+    title: 'Pekkas',
+    melody: 'Go West — Pet Shop Boys',
+    lines: [
+      'Pekkas — Vi tävlar varje år 🗓️',
+      'Pekkas — Dricker så mycket det går 🍻',
+      'Pekkas — Vi har det väldigt kul 🕺💃🎈🎊',
+      'Pekkas — Vi ses igen kring jul! 🎅🎄'
+    ]
+  }
+];
+
+// Export for global access
+window.PEKKAS_SONGS = PEKKAS_SONGS;

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -1900,6 +1900,59 @@
     }
   ];
 
+  /* ======================================================================
+     Sangboken
+     ====================================================================== */
+
+  function renderSongs() {
+    const picker = $('#song-picker');
+    const sheet = $('#song-sheet');
+    if (!picker || !sheet || typeof PEKKAS_SONGS === 'undefined') return;
+
+    const songs = PEKKAS_SONGS;
+
+    picker.innerHTML = songs
+      .map(
+        (song, i) => `
+        <button class="song-chip ${i === 0 ? 'active' : ''}" data-song="${song.id}">
+          <span class="song-chip-year">${song.year}</span>
+          <span class="song-chip-title">${esc(song.title)}</span>
+        </button>`
+      )
+      .join('');
+
+    const show = (id) => {
+      const song = songs.find((x) => x.id === id) || songs[0];
+      $$('#song-picker .song-chip').forEach((b) =>
+        b.classList.toggle('active', b.dataset.song === song.id)
+      );
+      const lines = song.lines
+        .map((line) => {
+          if (line === '') return '<div class="song-break"></div>';
+          if (typeof line === 'object') {
+            return `<div class="song-line"><span>${esc(line.o)}</span><small>${esc(line.t)}</small></div>`;
+          }
+          return `<div class="song-line"><span>${esc(line)}</span></div>`;
+        })
+        .join('');
+      sheet.innerHTML = `
+        <header class="song-head">
+          <span class="song-year-badge">${song.year}</span>
+          <h2>${esc(song.title)}</h2>
+          ${song.subtitle ? `<p class="song-subtitle">${esc(song.subtitle)}</p>` : ''}
+          ${song.melody ? `<p class="song-melody">\u266a Melodi: ${esc(song.melody)}</p>` : ''}
+        </header>
+        <div class="song-lyrics">${lines}</div>
+        <footer class="song-foot">Skal! \ud83c\udf7b</footer>`;
+    };
+
+    picker.addEventListener('click', (e) => {
+      const btn = e.target.closest('.song-chip');
+      if (btn) show(btn.dataset.song);
+    });
+    show(songs[0].id);
+  }
+
   function renderGames() {
     const byYear = {};
     GAMES.forEach((g) => (byYear[g.year] = g));
@@ -2281,7 +2334,7 @@
     window.addEventListener('resize', positionNavIndicator);
 
     const hash = location.hash.replace('#', '');
-    if (['overview', 'medals', 'history', 'achievements', 'stats', 'games'].includes(hash)) {
+    if (['overview', 'medals', 'history', 'achievements', 'stats', 'songs', 'games'].includes(hash)) {
       App.currentView = hash;
     }
   }
@@ -2352,6 +2405,7 @@
       renderStatsView();
       renderH2HControls();
       renderElo();
+      renderSongs();
       renderGames();
       initMap();
 

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1800,3 +1800,122 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35), 0 0 0 12px rgba(124, 140, 248, 0);
   }
 }
+
+/* ==========================================================================
+   Sångboken
+   ========================================================================== */
+
+.song-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: var(--sp-5);
+}
+
+.song-chip {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  background: var(--surface-2, rgba(21, 27, 52, 0.7));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: border-color 0.2s, transform 0.2s, background 0.2s;
+}
+
+.song-chip:hover {
+  transform: translateY(-2px);
+  border-color: rgba(242, 193, 78, 0.4);
+}
+
+.song-chip.active {
+  background: linear-gradient(160deg, rgba(242, 193, 78, 0.16), rgba(21, 27, 52, 0.8));
+  border-color: rgba(242, 193, 78, 0.55);
+}
+
+.song-chip-year {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--gold, #f2c14e);
+}
+
+.song-chip-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text-1, #e8ecfb);
+}
+
+.song-sheet {
+  max-width: 640px;
+  padding: clamp(24px, 5vw, 44px);
+  text-align: center;
+}
+
+.song-head h2 {
+  margin: 6px 0 2px;
+  font-family: 'Space Grotesk', Inter, sans-serif;
+  font-size: clamp(24px, 4.5vw, 34px);
+  color: var(--text-0, #fff);
+}
+
+.song-year-badge {
+  display: inline-block;
+  padding: 3px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--gold, #f2c14e);
+  background: rgba(242, 193, 78, 0.12);
+  border: 1px solid rgba(242, 193, 78, 0.35);
+}
+
+.song-subtitle {
+  margin: 2px 0 0;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-2, rgba(220, 226, 250, 0.65));
+}
+
+.song-melody {
+  margin: 8px 0 0;
+  font-style: italic;
+  font-size: 14px;
+  color: var(--gold, #f2c14e);
+  opacity: 0.85;
+}
+
+.song-lyrics {
+  margin: 26px 0 10px;
+  display: grid;
+  gap: 9px;
+}
+
+.song-line span {
+  display: block;
+  font-size: clamp(16px, 2.6vw, 19px);
+  line-height: 1.5;
+  color: var(--text-1, #e8ecfb);
+}
+
+.song-line small {
+  display: block;
+  font-size: 13px;
+  color: var(--text-2, rgba(220, 226, 250, 0.55));
+  font-style: italic;
+}
+
+.song-break {
+  height: 14px;
+}
+
+.song-foot {
+  margin-top: 22px;
+  font-size: 14px;
+  letter-spacing: 0.1em;
+  color: var(--text-2, rgba(220, 226, 250, 0.6));
+}


### PR DESCRIPTION
A new **Sånger** tab collects every song written for Pekkas Pokal, gathered from the *Snapsvisor* folder in the association's Google Drive — photos of notes and shared documents, transcribed by hand:

| År | Sång | Melodi |
| --- | --- | --- |
| 2026 | **Cant del Barça** | FC Barcelonas hymn — officiell låt för Barcelona, katalanska med svensk översättning under varje rad |
| 2022 | **Vi drar till Pekkas** | Vi drar till fjällen — Markoolio |
| 2022 | **För alla vi som tävlat i Pekkas** | När vi gräver guld i USA — GES |
| 2022 | **Vi älskar Pekkas** | Ramsa (WOOP WOOP) |
| 2022 | **Pekkas ☀️** | Ramsa |
| 2021 | **Viktor Jones fylledräng** | Trad. — ur gruppchatten 8 aug 2021 |
| 2021 | **Pekkas** | Go West — Pet Shop Boys |

## How it works
- Songs live in `src/data/songs.js` as a plain list (same global-script pattern as `achievements.js`), so adding next year's song is a small edit — documented in the README.
- The tab shows a picker of year-badged chips and a song sheet with title, melody line and lyrics. Translated songs render the Swedish line in small italics under each original line.
- Reachable from the top nav, the mobile tab bar (new music-note icon) and the `#songs` hash.

## Verified
Desktop + mobile viewports: seven chips render, selection switches the sheet, zero console errors, ESLint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb)_