### PR TITLE
Sångboken: fix footer typo — Skål, not Skal

### DIFF
--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -1943,7 +1943,7 @@
           ${song.melody ? `<p class="song-melody">\u266a Melodi: ${esc(song.melody)}</p>` : ''}
         </header>
         <div class="song-lyrics">${lines}</div>
-        <footer class="song-foot">Skal! \ud83c\udf7b</footer>`;
+        <footer class="song-foot">Sk\u00e5l! \ud83c\udf7b</footer>`;
     };
 
     picker.addEventListener('click', (e) => {


### PR DESCRIPTION
The song-sheet footer said "Skal! 🍻" — an å lost to a quoting workaround when the renderer was first written. Now correctly toasts **Skål! 🍻** on every song. Verified rendered output in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb)_