### PR TITLE
Pekkas Fiske: bygg om spelet till bästa möjliga 3D, grafik och känsla

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ väljaren automatiskt. En rad kan också vara `{ o: 'originalrad', t:
 Fliken **Spel** innehåller ett spel per år. 2025 är *Pekkas Pokal Flipper* — ett
 flipperspel i Three.js som byggs helt i webbläsaren (ingen bild- eller
 ljudfil laddas ner, bara Three.js självt, och först när man öppnar spelet).
+2024 är *Pekkas Fiske* — ett fiskespel med samma teknik, inspirerat av
+Ridiculous Fishings prisbelönta spelloop.
 
 Att lägga till ett nytt års spel:
 
@@ -96,6 +98,24 @@ Att lägga till ett nytt års spel:
    `year`, `title`, `tagline`, `icon` och sökvägen i `module`.
 
 År utan spel visas automatiskt som "inte byggt än".
+
+**Pekkas Fiske (2024)**
+
+Tre kast per fiskeafton, på en fjällsjö i midnattssol. Varje kast har tre
+faser, med samma återkopplingsloop som Ridiculous Fishing:
+
+1. **Nedåt** — styr draget (dra med fingret eller ←/→) och **väj** för fisken.
+   Nuddar du en fisk krokas den direkt; ju djupare du kommer, desto finare
+   arter väntar. På 50+ meter simmar **PEKKAGÄDDAN** — 500 poäng, guldfärgad
+   och krönt.
+2. **Uppåt** — veven går! Nu ska du **träffa** allt på vägen upp; varje fisk
+   ger poäng och kombon stiger.
+3. **I luften** — fångsten kastas upp ur vattnet. Tryck på fiskarna innan de
+   plumsar i igen: träff ger **dubbla poäng** i tunnan.
+
+Sex arter från mört till lax, djupgraderat ljus och dimma, syntetiserat ljud
+och rekord sparat per enhet. Allt är procedurellt byggt — inga bilder eller
+ljudfiler laddas ner.
 
 **Kontroller i flipperspelet**
 

--- a/README.md
+++ b/README.md
@@ -101,21 +101,45 @@ Att lägga till ett nytt års spel:
 
 **Pekkas Fiske (2024)**
 
-Tre kast per fiskeafton, på en fjällsjö i midnattssol. Varje kast har tre
-faser, med samma återkopplingsloop som Ridiculous Fishing:
+Tre kast per fiskeafton på en 60 meter djup sjö i midnattssol. Varje kast har
+tre faser, och det som gör loopen bra är att varje fas vänder på förra:
 
-1. **Nedåt** — styr draget (dra med fingret eller ←/→) och **väj** för fisken.
-   Nuddar du en fisk krokas den direkt; ju djupare du kommer, desto finare
-   arter väntar. På 50+ meter simmar **PEKKAGÄDDAN** — 500 poäng, guldfärgad
-   och krönt.
-2. **Uppåt** — veven går! Nu ska du **träffa** allt på vägen upp; varje fisk
-   ger poäng och kombon stiger.
-3. **I luften** — fångsten kastas upp ur vattnet. Tryck på fiskarna innan de
-   plumsar i igen: träff ger **dubbla poäng** i tunnan.
+1. **Nedåt — väj.** Styr draget (dra med fingret eller ←/→) och slipp *förbi*
+   fisken. Varje fisk du väjer för höjer multiplikatorn, och eftersom de fina
+   arterna bara simmar djupt är belöningen för att väja bra att få väja mer.
+   Nuddar du en fisk krokas den direkt. Nuddar du **skräp** — en gammal
+   stövel, en rostig burk, ett cykeldäck — är kastet bränt och multiplikatorn
+   nollad.
+2. **Uppåt — träffa.** Nu gäller tvärtom: veven går och allt du nuddar åker
+   med. Multiplikatorn du samlade på vägen ner spenderas här.
+3. **I luften — tryck.** Fångsten slungas upp över båten. Tryck på fiskarna
+   innan de plumsar i igen så åker de i tunnan. Träffar på rad kedjar ihop
+   sig, och tar du alla blir det **perfekt kast**.
 
-Sex arter från mört till lax, djupgraderat ljus och dimma, syntetiserat ljud
-och rekord sparat per enhet. Allt är procedurellt byggt — inga bilder eller
-ljudfiler laddas ner.
+Går du hela vägen till botten utan att nudda något får du **bottenkänning**:
+stor bonus och full multiplikator.
+
+| Djupzon | Från | Vad som simmar där |
+| --- | --- | --- |
+| Ytvattnet | 0 m | Mört (100), abborre (250) |
+| Sikdjupet | 12 m | Sik (400) |
+| Gäddgraven | 24 m | Gädda (800) |
+| Laxdjupet | 38 m | Lax (1 500) |
+| Pekkadjupet | 50 m | **PEKKAGÄDDAN** (5 000) — guldfärgad, krönt, inte alltid hemma |
+
+**Teknik.** Allt är procedurellt: inte en enda bild- eller ljudfil laddas ner,
+bara Three.js självt. Varje fiskart byggs från en ryggradsprofil plus
+fenblad och slås ihop till tre meshar per art, så hela stimmet ryms på ett
+femtiotal draw calls. Mönstren — motskuggningen, abborrens ränder, gäddans
+ljusa bönfläckar, laxens prickar — målas in i vertexfärgerna medan kroppen
+genereras. Vattenytan förskjuts på GPU:n och skuggas olika ovanifrån och
+underifrån: nerifrån får man Snells fönster (ljust rakt upp, spegel i sneda
+vinklar) med kaustik som kryper över taket, ovanifrån en solglitterstig.
+Kaustiktexturen är genererad ur vågintereferens så att den kaklar sömlöst.
+Djupet styr färg, dimma, ljus — och ett lågpassfilter på hela ljudbussen, så
+världen blir bokstavligen dovare ju längre ner man kommer. Ingen
+efterbehandling: ACES-tonemappning gör jobbet i stället, så telefonen
+behåller sin bildfrekvens.
 
 **Kontroller i flipperspelet**
 
@@ -177,6 +201,7 @@ npm run lint     # ESLint
 | `src/data/achievements.js` | Definitioner av alla utmärkelser |
 | `src/styles/` | `main` (tokens/teman), `layout`, `components`, `animations`, `games`, `responsive` |
 | `src/games/pinball/` | Flipperspelet: `physics` (2D-kollision), `table` (layout + banans grafik), `meshes` (3D), `index` (spelloop) |
+| `src/games/fishing/` | Fiskespelet: `species` (procedurella fiskar), `world` (sjö, vattenshader, båt), `audio` (syntetiskt ljud), `index` (spelloop) |
 | `public/` | Statiska filer: `event.json`, `manifest.json`, ikoner, `og-image.png`, `photos/` |
 
 Data hämtas från `competition-data.csv` vid sidladdning. Om filen inte går att

--- a/src/games/fishing/audio.js
+++ b/src/games/fishing/audio.js
@@ -1,0 +1,182 @@
+/**
+ * Pekkas Fiske — synthesized audio.
+ *
+ * Everything is generated in the browser: no audio files are downloaded.
+ * The whole bus runs through a low-pass that closes as the lure sinks, so
+ * the world literally gets muffled the deeper you go, plus a slow drone
+ * that swells in the dark. That single filter does more for the feeling of
+ * depth than any amount of extra sound effects.
+ */
+
+export class Sfx {
+  constructor() {
+    this.ctx = null;
+    this.muted = false;
+    this.reelAt = 0;
+  }
+
+  resume() {
+    if (!this.ctx) {
+      const AC = window.AudioContext || window.webkitAudioContext;
+      if (!AC) return;
+      this.ctx = new AC();
+
+      // master -> depth low-pass -> soft limiter -> out
+      this.master = this.ctx.createGain();
+      this.master.gain.value = 0.32;
+
+      this.lp = this.ctx.createBiquadFilter();
+      this.lp.type = 'lowpass';
+      this.lp.frequency.value = 18000;
+      this.lp.Q.value = 0.4;
+
+      const comp = this.ctx.createDynamicsCompressor();
+      comp.threshold.value = -14;
+      comp.knee.value = 22;
+      comp.ratio.value = 6;
+      comp.attack.value = 0.004;
+      comp.release.value = 0.16;
+
+      this.master.connect(this.lp).connect(comp).connect(this.ctx.destination);
+
+      // Ambient drone: two detuned saws swelling with depth
+      this.droneGain = this.ctx.createGain();
+      this.droneGain.gain.value = 0;
+      this.droneGain.connect(this.master);
+      [55, 55.6, 82.5].forEach((f, i) => {
+        const o = this.ctx.createOscillator();
+        o.type = i === 2 ? 'sine' : 'sawtooth';
+        o.frequency.value = f;
+        const g = this.ctx.createGain();
+        g.gain.value = i === 2 ? 0.35 : 0.2;
+        o.connect(g).connect(this.droneGain);
+        o.start();
+      });
+    }
+    if (this.ctx.state === 'suspended') this.ctx.resume();
+  }
+
+  /** Depth in metres drives the muffling and the drone. */
+  setDepth(d, maxDepth) {
+    if (!this.ctx) return;
+    const k = Math.min(1, Math.max(0, d / maxDepth));
+    const t = this.ctx.currentTime;
+    // 18 kHz at the surface down to a dull 520 Hz on the bottom
+    this.lp.frequency.setTargetAtTime(520 + (1 - k) * 17480, t, 0.25);
+    this.droneGain.gain.setTargetAtTime(this.muted ? 0 : k * k * 0.16, t, 0.4);
+  }
+
+  tone(freq, dur, type = 'sine', gain = 0.5, sweep = 0, delay = 0) {
+    if (!this.ctx || this.muted) return;
+    const t = this.ctx.currentTime + delay;
+    const osc = this.ctx.createOscillator();
+    const env = this.ctx.createGain();
+    osc.type = type;
+    osc.frequency.setValueAtTime(freq, t);
+    if (sweep) osc.frequency.exponentialRampToValueAtTime(Math.max(30, freq + sweep), t + dur);
+    env.gain.setValueAtTime(0.0001, t);
+    env.gain.exponentialRampToValueAtTime(gain, t + 0.008);
+    env.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+    osc.connect(env).connect(this.master);
+    osc.start(t);
+    osc.stop(t + dur + 0.02);
+  }
+
+  noise(dur, gain = 0.4, freq = 800, q = 1, sweepTo = 0) {
+    if (!this.ctx || this.muted) return;
+    const t = this.ctx.currentTime;
+    const n = Math.max(1, Math.floor(this.ctx.sampleRate * dur));
+    const buf = this.ctx.createBuffer(1, n, this.ctx.sampleRate);
+    const data = buf.getChannelData(0);
+    for (let i = 0; i < n; i++) data[i] = (Math.random() * 2 - 1) * (1 - i / n) ** 1.5;
+    const src = this.ctx.createBufferSource();
+    src.buffer = buf;
+    const filt = this.ctx.createBiquadFilter();
+    filt.type = 'bandpass';
+    filt.frequency.setValueAtTime(freq, t);
+    filt.Q.value = q;
+    if (sweepTo) filt.frequency.exponentialRampToValueAtTime(Math.max(60, sweepTo), t + dur);
+    const env = this.ctx.createGain();
+    env.gain.value = gain;
+    src.connect(filt).connect(env).connect(this.master);
+    src.start(t);
+  }
+
+  /** Fat splash: broadband burst sweeping down, plus a body thump. */
+  splash(strength = 1) {
+    this.noise(0.42 * strength, 0.55 * strength, 1600, 0.7, 260);
+    this.tone(190, 0.28, 'sine', 0.34 * strength, -110);
+  }
+
+  plopp() {
+    this.tone(320, 0.09, 'sine', 0.45, -170);
+    this.noise(0.07, 0.16, 1200);
+  }
+
+  /** The strike: a taut snap plus line whip. */
+  hook() {
+    this.tone(760, 0.1, 'square', 0.42, 340);
+    this.tone(190, 0.22, 'sine', 0.3, 90);
+    this.noise(0.11, 0.34, 2400, 1.4);
+  }
+
+  /** Rising chime that climbs with the combo — the engine of the reel phase. */
+  catchFish(n) {
+    const step = Math.min(n, 12);
+    const f = 392 * 1.0595 ** (step * 2);
+    this.tone(f, 0.11, 'triangle', 0.42, 90);
+    this.tone(f * 2, 0.07, 'sine', 0.16, 60, 0.02);
+  }
+
+  /** Ratcheting reel — call every frame, it rate-limits itself. */
+  reelTick(speed) {
+    if (!this.ctx || this.muted) return;
+    const now = this.ctx.currentTime;
+    const gap = Math.max(0.022, 0.14 - speed * 0.007);
+    if (now - this.reelAt < gap) return;
+    this.reelAt = now;
+    this.tone(1200 + Math.random() * 500, 0.02, 'square', 0.075);
+  }
+
+  dodge(n) {
+    this.tone(880 * 1.05 ** Math.min(n, 10), 0.05, 'sine', 0.13, 160);
+  }
+
+  junk() {
+    this.tone(120, 0.32, 'sawtooth', 0.3, -50);
+    this.noise(0.3, 0.3, 420, 0.8);
+  }
+
+  toss() {
+    this.noise(0.34, 0.42, 900, 0.6, 2600);
+    this.tone(220, 0.34, 'sawtooth', 0.26, 520);
+  }
+
+  tap(n) {
+    const f = 523 * 1.0595 ** (Math.min(n, 10) * 2);
+    this.tone(f, 0.1, 'square', 0.36, 180);
+    this.tone(f * 1.5, 0.06, 'sine', 0.14, 0, 0.02);
+  }
+
+  miss() {
+    this.tone(210, 0.22, 'sine', 0.26, -95);
+  }
+
+  zone() {
+    [0, 130].forEach((d, i) => this.tone(294 * (i ? 1.5 : 1), 0.3, 'sine', 0.22, 0, d / 1000));
+  }
+
+  legend() {
+    [0, 105, 210, 315, 450, 620].forEach((d, i) =>
+      this.tone(392 * 2 ** (i / 4), 0.26, 'triangle', 0.46, 0, d / 1000));
+    this.noise(0.8, 0.2, 3200, 0.8, 900);
+  }
+
+  fanfare() {
+    [0, 1, 2, 4].forEach((s, i) =>
+      this.tone(392 * 1.0595 ** (s * 2), 0.26, 'triangle', 0.44, 0, i * 0.11));
+    this.tone(196, 0.9, 'sine', 0.24, 0, 0.44);
+  }
+}
+
+export default Sfx;

--- a/src/games/fishing/index.js
+++ b/src/games/fishing/index.js
@@ -1,110 +1,63 @@
 /**
  * Pekkas Fiske — the 2024 competition as a Three.js fishing game.
  *
- * The loop is borrowed from the most loved mobile fishing game there is:
- * steer the lure PAST the fish on the way down (deeper = better fish),
- * hook one and catch everything you can on the way up, then the whole
- * stringer is flung into the air and every fish you TAP lands in the
- * tunna for double points. Three casts per game.
+ * The loop is the one Ridiculous Fishing won an Apple Design Award with,
+ * and it works because each phase inverts the last:
  *
- * Everything is procedural: low-poly fish, a rowing boat on a midnight-sun
- * lake, depth-graded water and synthesized sound. The only download is
- * Three.js itself.
+ *   1. DROP  — steer PAST the fish. Every one you slip by raises the
+ *              multiplier, and the good species only live deep, so the
+ *              reward for dodging well is the right to keep dodging.
+ *   2. REEL  — the rule flips: now hit everything. The multiplier you
+ *              earned on the way down is spent on the way up.
+ *   3. TOSS  — the catch is flung over the boat and you tap it into the
+ *              tunna for double.
+ *
+ * Everything is procedural — geometry, caustics, sound. The only thing
+ * downloaded is Three.js itself, and only when the game is opened.
  */
 
 import * as THREE from 'three';
+import { Sfx } from './audio.js';
+import { SPECIES, JUNK, fishAssets, spawnFish, spawnJunk, swim, disposeAssets } from './species.js';
+import {
+  BOTTOM, causticTexture, sparkTexture, buildSky, buildShore, buildWater, buildBoat,
+  buildSeabed, buildShafts, buildSnow, buildBurst, emitBurst, updateBurst, buildLure, buildLine
+} from './world.js';
 
 const CASTS_PER_GAME = 3;
-const BOTTOM = 60; // metres — Själevadsfjärden runs deep
 const HIGHSCORE_KEY = 'pp-fiske-highscore';
 
-/* ---------------------------------------------------------------- species */
-
-const SPECIES = [
-  { id: 'mort', name: 'Mört', pts: 10, min: 2, max: 16, size: 0.55, color: 0xb9c4d6, belly: 0xe8edf5, speed: 2.6 },
-  { id: 'abborre', name: 'Abborre', pts: 25, min: 5, max: 30, size: 0.7, color: 0x5f8f5a, belly: 0xd8e9c8, speed: 3.1 },
-  { id: 'sik', name: 'Sik', pts: 40, min: 14, max: 42, size: 0.8, color: 0x9fb4c8, belly: 0xeef4fa, speed: 3.4 },
-  { id: 'gadda', name: 'Gädda', pts: 80, min: 20, max: 52, size: 1.25, color: 0x4a6b3f, belly: 0xcfe0b8, speed: 3.9 },
-  { id: 'lax', name: 'Lax', pts: 150, min: 34, max: 58, size: 1.05, color: 0x8a92b8, belly: 0xf3c9b8, speed: 4.6 },
-  { id: 'pekka', name: 'PEKKAGÄDDAN', pts: 500, min: 50, max: 59, size: 1.9, color: 0xf2c14e, belly: 0xfff3cf, speed: 5.2, rare: true }
+/** Water colour by depth — five stops instead of a straight fade. */
+const WATER_STOPS = [
+  [0, 0x3ec2c4], [8, 0x1f8f96], [18, 0x136d82],
+  [30, 0x0b4667], [44, 0x062a48], [60, 0x02101f]
 ];
 
-/* ------------------------------------------------------------------ audio */
+const ZONES = [
+  { at: 0, name: 'YTVATTNET' },
+  { at: 12, name: 'SIKDJUPET' },
+  { at: 24, name: 'GÄDDGRAVEN' },
+  { at: 38, name: 'LAXDJUPET' },
+  { at: 50, name: 'PEKKADJUPET' }
+];
 
-class Sfx {
-  constructor() {
-    this.ctx = null;
-    this.muted = false;
-  }
-
-  resume() {
-    if (!this.ctx) {
-      const AC = window.AudioContext || window.webkitAudioContext;
-      if (!AC) return;
-      this.ctx = new AC();
-      this.master = this.ctx.createGain();
-      this.master.gain.value = 0.3;
-      this.master.connect(this.ctx.destination);
+function gradient(stops, d, out) {
+  for (let i = 0; i < stops.length - 1; i++) {
+    const [d0, c0] = stops[i];
+    const [d1, c1] = stops[i + 1];
+    if (d <= d1 || i === stops.length - 2) {
+      const k = Math.min(1, Math.max(0, (d - d0) / (d1 - d0)));
+      return out.set(c0).lerp(new THREE.Color(c1), k);
     }
-    if (this.ctx.state === 'suspended') this.ctx.resume();
   }
-
-  tone(freq, dur, type = 'sine', gain = 0.5, sweep = 0) {
-    if (!this.ctx || this.muted) return;
-    const t = this.ctx.currentTime;
-    const osc = this.ctx.createOscillator();
-    const env = this.ctx.createGain();
-    osc.type = type;
-    osc.frequency.setValueAtTime(freq, t);
-    if (sweep) osc.frequency.exponentialRampToValueAtTime(Math.max(30, freq + sweep), t + dur);
-    env.gain.setValueAtTime(0.0001, t);
-    env.gain.exponentialRampToValueAtTime(gain, t + 0.008);
-    env.gain.exponentialRampToValueAtTime(0.0001, t + dur);
-    osc.connect(env).connect(this.master);
-    osc.start(t);
-    osc.stop(t + dur + 0.02);
-  }
-
-  noise(dur, gain = 0.4, freq = 800) {
-    if (!this.ctx || this.muted) return;
-    const t = this.ctx.currentTime;
-    const n = Math.floor(this.ctx.sampleRate * dur);
-    const buf = this.ctx.createBuffer(1, n, this.ctx.sampleRate);
-    const data = buf.getChannelData(0);
-    for (let i = 0; i < n; i++) data[i] = (Math.random() * 2 - 1) * (1 - i / n);
-    const src = this.ctx.createBufferSource();
-    src.buffer = buf;
-    const filt = this.ctx.createBiquadFilter();
-    filt.type = 'bandpass';
-    filt.frequency.value = freq;
-    const env = this.ctx.createGain();
-    env.gain.value = gain;
-    src.connect(filt).connect(env).connect(this.master);
-    src.start(t);
-  }
-
-  splash() { this.noise(0.35, 0.5, 500); this.tone(180, 0.25, 'sine', 0.3, -80); }
-  plopp() { this.tone(300, 0.09, 'sine', 0.5, -140); }
-  hook() { this.tone(700, 0.09, 'square', 0.4, 300); this.noise(0.08, 0.3, 1800); }
-  catchFish(n) { this.tone(420 * 1.12 ** Math.min(n, 10), 0.1, 'triangle', 0.5, 120); }
-  reel() { this.tone(1400, 0.025, 'square', 0.12); }
-  toss() { this.noise(0.3, 0.4, 700); this.tone(220, 0.3, 'sawtooth', 0.3, 400); }
-  tap(n) { this.tone(520 * 1.12 ** Math.min(n, 8), 0.12, 'square', 0.45, 200); }
-  miss() { this.tone(200, 0.2, 'sine', 0.3, -90); }
-  legend() {
-    [0, 110, 220, 330, 480].forEach((d, i) =>
-      setTimeout(() => this.tone(392 * 2 ** (i / 4), 0.22, 'triangle', 0.5), d));
-  }
-  fanfare() {
-    [0, 90, 180, 340].forEach((d, i) =>
-      setTimeout(() => this.tone(523 * (1 + i * 0.25), 0.2, 'triangle', 0.5), d));
-  }
+  return out.set(stops[0][1]);
 }
 
 /* ------------------------------------------------------------------- HUD */
 
 function buildHud(root) {
   root.innerHTML = `
+    <div class="fg-vignette"></div>
     <div class="pb-hud">
       <div class="pb-top">
         <div class="pb-score-wrap">
@@ -116,15 +69,24 @@ function buildHud(root) {
           <div class="fg-cast" id="fg-cast"></div>
         </div>
       </div>
+      <div class="fg-mult" id="fg-mult"></div>
+      <div class="fg-zone" id="fg-zone"></div>
       <div class="fg-phase" id="fg-phase"></div>
       <div class="pb-toast" id="fg-toast"></div>
+      <div class="fg-pops" id="fg-pops"></div>
     </div>
 
     <div class="pb-overlay" id="fg-overlay">
       <div class="pb-panel">
         <h2 id="fg-title">Pekkas Fiske</h2>
-        <p id="fg-text">Styr draget genom att dra med fingret. Väj för fisken på väg ner — kroka djupt, fånga allt på väg upp och tryck på fisken i luften!</p>
+        <p id="fg-text">Tre kast. Dra med fingret för att styra draget.</p>
+        <ul class="fg-steps" id="fg-steps">
+          <li><i style="--c:#7fd8e8"></i><b>Ner</b> Väj för fisken — varje fisk du slipper förbi höjer multiplikatorn.</li>
+          <li><i style="--c:#f2c14e"></i><b>Upp</b> Nu gäller tvärtom: fånga allt på vägen upp.</li>
+          <li><i style="--c:#5eead4"></i><b>I luften</b> Tryck på fångsten så åker den i tunnan — dubbla poäng.</li>
+        </ul>
         <div class="pb-scoreline" id="fg-scoreline" hidden></div>
+        <div class="fg-catchlist" id="fg-catchlist" hidden></div>
         <button class="pb-btn" id="fg-start">Kasta i!</button>
       </div>
     </div>
@@ -135,118 +97,14 @@ function buildHud(root) {
       </svg>
     </button>
   `;
+  const q = (s) => root.querySelector(s);
   return {
-    score: root.querySelector('#fg-score'),
-    hi: root.querySelector('#fg-hi'),
-    depth: root.querySelector('#fg-depth'),
-    cast: root.querySelector('#fg-cast'),
-    phase: root.querySelector('#fg-phase'),
-    toast: root.querySelector('#fg-toast'),
-    overlay: root.querySelector('#fg-overlay'),
-    title: root.querySelector('#fg-title'),
-    text: root.querySelector('#fg-text'),
-    scoreline: root.querySelector('#fg-scoreline'),
-    start: root.querySelector('#fg-start'),
-    mute: root.querySelector('#fg-mute')
+    score: q('#fg-score'), hi: q('#fg-hi'), depth: q('#fg-depth'), cast: q('#fg-cast'),
+    mult: q('#fg-mult'), zone: q('#fg-zone'), phase: q('#fg-phase'), toast: q('#fg-toast'),
+    pops: q('#fg-pops'), overlay: q('#fg-overlay'), title: q('#fg-title'), text: q('#fg-text'),
+    steps: q('#fg-steps'), scoreline: q('#fg-scoreline'), catchlist: q('#fg-catchlist'),
+    start: q('#fg-start'), mute: q('#fg-mute')
   };
-}
-
-/* ------------------------------------------------------------------ world */
-
-function buildFishMesh(sp) {
-  const g = new THREE.Group();
-  const bodyMat = new THREE.MeshLambertMaterial({ color: sp.color, flatShading: true });
-  const bellyMat = new THREE.MeshLambertMaterial({ color: sp.belly, flatShading: true });
-
-  const body = new THREE.Mesh(new THREE.SphereGeometry(0.5, 7, 5), bodyMat);
-  body.scale.set(1.7, 0.62, 0.5);
-  g.add(body);
-
-  const belly = new THREE.Mesh(new THREE.SphereGeometry(0.42, 7, 5), bellyMat);
-  belly.scale.set(1.5, 0.5, 0.42);
-  belly.position.y = -0.1;
-  g.add(belly);
-
-  const tail = new THREE.Mesh(new THREE.ConeGeometry(0.34, 0.62, 4), bodyMat);
-  tail.rotation.z = Math.PI / 2;
-  tail.position.x = -1.0;
-  tail.scale.z = 0.4;
-  g.add(tail);
-
-  const fin = new THREE.Mesh(new THREE.ConeGeometry(0.18, 0.4, 4), bodyMat);
-  fin.position.set(0.1, 0.4, 0);
-  fin.scale.z = 0.4;
-  g.add(fin);
-
-  const eyeGeo = new THREE.SphereGeometry(0.07, 6, 4);
-  const eyeMat = new THREE.MeshBasicMaterial({ color: 0x10152a });
-  [0.26, -0.26].forEach((z) => {
-    const eye = new THREE.Mesh(eyeGeo, eyeMat);
-    eye.position.set(0.62, 0.08, z * 0.5);
-    g.add(eye);
-  });
-
-  if (sp.rare) {
-    const crown = new THREE.Mesh(
-      new THREE.ConeGeometry(0.22, 0.34, 5),
-      new THREE.MeshLambertMaterial({ color: 0xffe08a, emissive: 0xf2c14e, emissiveIntensity: 0.7 })
-    );
-    crown.position.set(0.45, 0.55, 0);
-    g.add(crown);
-  }
-
-  g.scale.setScalar(sp.size);
-  g.userData.tail = tail;
-  return g;
-}
-
-function buildBoat() {
-  const g = new THREE.Group();
-  const hullMat = new THREE.MeshLambertMaterial({ color: 0x8a5a2b, flatShading: true });
-  const hull = new THREE.Mesh(new THREE.CylinderGeometry(1.5, 0.9, 4.4, 6, 1), hullMat);
-  hull.rotation.z = Math.PI / 2;
-  hull.scale.y = 0.55;
-  hull.scale.z = 0.62;
-  g.add(hull);
-
-  const rim = new THREE.Mesh(new THREE.TorusGeometry(1.9, 0.12, 6, 12), hullMat);
-  rim.rotation.x = Math.PI / 2;
-  rim.scale.set(1.2, 0.62, 1);
-  rim.position.y = 0.72;
-  g.add(rim);
-
-  // Fisherman: cap, head, body
-  const guy = new THREE.Group();
-  const body = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.32, 0.45, 0.9, 6),
-    new THREE.MeshLambertMaterial({ color: 0xf2c14e, flatShading: true })
-  );
-  body.position.y = 1.15;
-  guy.add(body);
-  const head = new THREE.Mesh(
-    new THREE.SphereGeometry(0.26, 7, 5),
-    new THREE.MeshLambertMaterial({ color: 0xe8b88a, flatShading: true })
-  );
-  head.position.y = 1.85;
-  guy.add(head);
-  const cap = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.28, 0.3, 0.16, 7),
-    new THREE.MeshLambertMaterial({ color: 0xb23a48, flatShading: true })
-  );
-  cap.position.y = 2.02;
-  guy.add(cap);
-  // Fishing rod
-  const rod = new THREE.Mesh(
-    new THREE.CylinderGeometry(0.03, 0.05, 2.6, 5),
-    new THREE.MeshLambertMaterial({ color: 0x3a2b1a })
-  );
-  rod.position.set(1.1, 1.9, 0);
-  rod.rotation.z = -0.7;
-  guy.add(rod);
-  guy.position.x = -0.3;
-  g.add(guy);
-
-  return g;
 }
 
 /* ------------------------------------------------------------------- game */
@@ -263,183 +121,142 @@ export async function createFishing(container) {
 
   const sfx = new Sfx();
 
-  /* ---- Renderer: no post-processing — depth fog and flat shading carry
-     the look, and phones keep their frame rate ---- */
+  /* ---- Renderer: ACES filmic tone mapping does the heavy lifting on the
+     look. No post-processing — a phone keeps its frame rate instead. ---- */
   const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
   renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.12;
   canvasHost.appendChild(renderer.domElement);
 
   const scene = new THREE.Scene();
-  const SKY = new THREE.Color(0xffd9a0); // midnight sun
-  const SURF = new THREE.Color(0x1d6b74);
-  const DEEP = new THREE.Color(0x041020);
-  scene.background = SKY.clone();
-  scene.fog = new THREE.FogExp2(0x1d6b74, 0.028);
+  scene.fog = new THREE.FogExp2(0x1f8f96, 0.02);
+  scene.background = new THREE.Color(0x1f8f96);
 
-  const camera = new THREE.PerspectiveCamera(55, 1, 0.1, 120);
-  camera.position.set(0, 4, 16);
+  const camera = new THREE.PerspectiveCamera(56, 1, 0.1, 900);
+  camera.position.set(0, 3.4, 15);
 
-  /* ---- Lights ---- */
-  const hemi = new THREE.HemisphereLight(0xfff2d0, 0x0a2030, 1.0);
+  const hemi = new THREE.HemisphereLight(0xfff0d2, 0x0a2434, 1.15);
   scene.add(hemi);
-  const sun = new THREE.DirectionalLight(0xffe0b0, 1.4);
-  sun.position.set(-14, 20, 8);
+  const sun = new THREE.DirectionalLight(0xffe3b6, 1.7);
+  sun.position.set(-30, 40, -20);
   scene.add(sun);
 
-  /* ---- Sky: sun disc + shoreline silhouette ---- */
-  const skyGroup = new THREE.Group();
-  const sunDisc = new THREE.Mesh(
-    new THREE.CircleGeometry(3.2, 24),
-    new THREE.MeshBasicMaterial({ color: 0xffedc0, fog: false })
-  );
-  sunDisc.position.set(-10, 9.5, -30);
-  skyGroup.add(sunDisc);
-  const shoreMat = new THREE.MeshBasicMaterial({ color: 0x27333e, fog: false });
-  for (let i = 0; i < 26; i++) {
-    const h = 1.6 + Math.random() * 2.6;
-    const tree = new THREE.Mesh(new THREE.ConeGeometry(0.8, h, 5), shoreMat);
-    tree.position.set(-32 + i * 2.6 + Math.random(), 1.4 + h / 2, -28 - Math.random() * 4);
-    skyGroup.add(tree);
-  }
-  scene.add(skyGroup);
+  /* ---- World ---- */
+  const caustics = causticTexture();
+  const spark = sparkTexture();
 
-  /* ---- Water surface: CPU-displaced low-poly sheet, visible from below ---- */
-  const surfGeo = new THREE.PlaneGeometry(90, 44, 36, 14);
-  surfGeo.rotateX(-Math.PI / 2);
-  const surfMat = new THREE.MeshLambertMaterial({
-    color: 0x2a8b96,
-    flatShading: true,
-    transparent: true,
-    opacity: 0.92,
-    side: THREE.DoubleSide
-  });
-  const surface = new THREE.Mesh(surfGeo, surfMat);
-  surface.position.y = 0;
-  scene.add(surface);
-  const surfPos = surfGeo.attributes.position;
-  const surfBase = surfPos.array.slice();
+  const sky = buildSky();
+  scene.add(sky.dome);
+  const shore = buildShore();
+  scene.add(shore);
 
-  /* ---- Boat ---- */
+  const water = buildWater(caustics);
+  scene.add(water.mesh);
+
   const boat = buildBoat();
-  boat.position.set(0.5, 0.35, 0);
+  boat.position.set(0.4, -0.08, 0);
   scene.add(boat);
+  scene.add(boat.userData.foam);
 
-  /* ---- Light shafts near the surface ---- */
-  const shafts = [];
-  const shaftMat = new THREE.MeshBasicMaterial({
-    color: 0xbfe8d8,
-    transparent: true,
-    opacity: 0.1,
-    depthWrite: false,
-    blending: THREE.AdditiveBlending,
-    side: THREE.DoubleSide
-  });
-  for (let i = 0; i < 6; i++) {
-    const shaft = new THREE.Mesh(new THREE.PlaneGeometry(1.4 + Math.random(), 16), shaftMat);
-    shaft.position.set(-10 + i * 4 + Math.random() * 2, -8, -3 - Math.random() * 3);
-    shaft.rotation.z = -0.22 + Math.random() * 0.1;
-    scene.add(shaft);
-    shafts.push(shaft);
-  }
+  const shafts = buildShafts();
+  scene.add(shafts);
 
-  /* ---- Seabed ---- */
-  const bedGroup = new THREE.Group();
-  bedGroup.position.y = -BOTTOM - 1.2;
-  const bed = new THREE.Mesh(
-    new THREE.PlaneGeometry(80, 30, 24, 8),
-    new THREE.MeshLambertMaterial({ color: 0x2b3140, flatShading: true })
-  );
-  bed.rotation.x = -Math.PI / 2;
-  const bp = bed.geometry.attributes.position;
-  for (let i = 0; i < bp.count; i++) bp.setZ(i, Math.random() * 1.4);
-  bed.geometry.computeVertexNormals();
-  bedGroup.add(bed);
-  const stoneMat = new THREE.MeshLambertMaterial({ color: 0x3d4558, flatShading: true });
-  for (let i = 0; i < 10; i++) {
-    const stone = new THREE.Mesh(new THREE.DodecahedronGeometry(0.5 + Math.random() * 0.9, 0), stoneMat);
-    stone.position.set(-18 + Math.random() * 36, 0.4, -4 + Math.random() * 6);
-    bedGroup.add(stone);
-  }
-  const weedMat = new THREE.MeshLambertMaterial({ color: 0x1f5c48, flatShading: true });
-  const weeds = [];
-  for (let i = 0; i < 14; i++) {
-    const weed = new THREE.Mesh(new THREE.ConeGeometry(0.16, 2.2 + Math.random() * 1.8, 4), weedMat);
-    weed.position.set(-16 + Math.random() * 32, 1.2, -3 + Math.random() * 5);
-    bedGroup.add(weed);
-    weeds.push(weed);
-  }
-  scene.add(bedGroup);
+  const seabed = buildSeabed();
+  scene.add(seabed);
 
-  /* ---- Bubbles / drifting particles ---- */
-  const bubbleCount = 90;
-  const bubbleGeo = new THREE.BufferGeometry();
-  const bubblePos = new Float32Array(bubbleCount * 3);
-  for (let i = 0; i < bubbleCount; i++) {
-    bubblePos[i * 3] = -14 + Math.random() * 28;
-    bubblePos[i * 3 + 1] = -Math.random() * BOTTOM;
-    bubblePos[i * 3 + 2] = -4 + Math.random() * 6;
-  }
-  bubbleGeo.setAttribute('position', new THREE.BufferAttribute(bubblePos, 3));
-  const bubbles = new THREE.Points(
-    bubbleGeo,
-    new THREE.PointsMaterial({ color: 0x9fd8d0, size: 0.12, transparent: true, opacity: 0.5 })
-  );
-  scene.add(bubbles);
+  const snow = buildSnow(spark);
+  scene.add(snow);
+  const burst = buildBurst(spark);
+  scene.add(burst);
 
-  /* ---- Lure + line ---- */
-  const lure = new THREE.Group();
-  const sinker = new THREE.Mesh(
-    new THREE.SphereGeometry(0.28, 8, 6),
-    new THREE.MeshLambertMaterial({ color: 0xd23b4e, flatShading: true })
-  );
-  lure.add(sinker);
-  const hookMesh = new THREE.Mesh(
-    new THREE.TorusGeometry(0.16, 0.045, 6, 10, Math.PI * 1.4),
-    new THREE.MeshLambertMaterial({ color: 0xdfe6ff })
-  );
-  hookMesh.position.y = -0.34;
-  hookMesh.rotation.z = Math.PI * 0.8;
-  lure.add(hookMesh);
-  const glow = new THREE.PointLight(0xffd9a0, 0.7, 7, 2);
-  lure.add(glow);
+  const lure = buildLure();
   scene.add(lure);
-
-  const lineGeo = new THREE.BufferGeometry().setFromPoints([
-    new THREE.Vector3(),
-    new THREE.Vector3()
-  ]);
-  const line = new THREE.Line(lineGeo, new THREE.LineBasicMaterial({ color: 0xdde6f2, transparent: true, opacity: 0.6 }));
+  const line = buildLine();
   scene.add(line);
 
-  /* ---- Fish pool ---- */
+  const assets = fishAssets();
+  const speciesByIndex = assets.species;
+
+  /* ---- Shoal ---------------------------------------------------------- */
+
   const fishes = [];
-  function spawnFishSet() {
+
+  function clearFish() {
     fishes.forEach((f) => scene.remove(f.mesh));
     fishes.length = 0;
-    SPECIES.forEach((sp) => {
-      const count = sp.rare ? 1 : 9;
-      for (let i = 0; i < count; i++) {
-        if (sp.rare && Math.random() < 0.35) continue; // she is not always home
-        const mesh = buildFishMesh(sp);
-        const depth = sp.min + Math.random() * (sp.max - sp.min);
-        const dir = Math.random() < 0.5 ? 1 : -1;
-        mesh.position.set(-14 + Math.random() * 28, -depth, -1.5 + Math.random() * 3);
-        mesh.scale.x *= dir > 0 ? 1 : -1;
-        scene.add(mesh);
-        fishes.push({
-          sp,
-          mesh,
-          dir,
-          speed: sp.speed * (0.8 + Math.random() * 0.5),
-          phase: Math.random() * Math.PI * 2,
-          caught: false,
-          air: null
-        });
-      }
+  }
+
+  function addFish(asset, depth, deco) {
+    const mesh = spawnFish(asset);
+    const dir = Math.random() < 0.5 ? 1 : -1;
+    const z = deco
+      ? (Math.random() < 0.5 ? -1 : 1) * (3.5 + Math.random() * 6)
+      : (Math.random() - 0.5) * 1.4;
+    mesh.position.set(-16 + Math.random() * 32, -depth, z);
+    mesh.rotation.y = dir > 0 ? 0 : Math.PI;
+    if (deco) mesh.scale.multiplyScalar(0.8 + Math.random() * 0.5);
+    scene.add(mesh);
+    fishes.push({
+      sp: asset.sp,
+      mesh,
+      dir,
+      deco: !!deco,
+      speed: asset.sp.speed * (0.8 + Math.random() * 0.5),
+      phase: Math.random() * Math.PI * 2,
+      bob: 0.2 + Math.random() * 0.5,
+      caught: false,
+      dodged: false,
+      junk: false,
+      air: null
     });
   }
 
-  /* ------------------------------------------------------------- state */
+  function addJunk(asset) {
+    const mesh = spawnJunk(asset);
+    const depth = asset.junk.min + Math.random() * (asset.junk.max - asset.junk.min);
+    mesh.position.set(-15 + Math.random() * 30, -depth, (Math.random() - 0.5) * 1.2);
+    scene.add(mesh);
+    fishes.push({
+      sp: { name: asset.junk.name, pts: 0, size: asset.junk.size, speed: 0.4 },
+      mesh,
+      dir: Math.random() < 0.5 ? 1 : -1,
+      deco: false,
+      speed: 0.5,
+      phase: Math.random() * Math.PI * 2,
+      bob: 0.3,
+      caught: false,
+      dodged: false,
+      junk: true,
+      air: null
+    });
+  }
+
+  function spawnFishSet() {
+    clearFish();
+    speciesByIndex.forEach((asset) => {
+      const { sp } = asset;
+      if (sp.rare) {
+        if (Math.random() < 0.4) return; // she is not always home
+        addFish(asset, sp.min + Math.random() * (sp.max - sp.min), false);
+        return;
+      }
+      const n = 7;
+      for (let i = 0; i < n; i++) {
+        addFish(asset, sp.min + Math.random() * (sp.max - sp.min), false);
+      }
+      for (let i = 0; i < 3; i++) {
+        addFish(asset, sp.min + Math.random() * (sp.max - sp.min), true);
+      }
+    });
+    assets.junk.forEach((asset) => {
+      addJunk(asset);
+      if (Math.random() < 0.6) addJunk(asset);
+    });
+  }
+
+  /* ---- State ---------------------------------------------------------- */
 
   const state = {
     phase: 'idle', // idle | drop | reel | toss | between | over
@@ -448,12 +265,17 @@ export async function createFishing(container) {
     depth: 0,
     lureX: 0,
     targetX: 0,
-    dropSpeed: 6,
+    dropSpeed: 6.5,
     caught: [],
     combo: 0,
+    dodges: 0,
+    mult: 1,
+    tapChain: 0,
     tossLeft: 0,
-    best: 0,
-    lastToast: 0
+    zone: -1,
+    deepest: 0,
+    lastToast: 0,
+    timers: []
   };
 
   let high = 0;
@@ -462,9 +284,42 @@ export async function createFishing(container) {
   } catch (e) {
     high = 0;
   }
-  hud.hi.textContent = high.toLocaleString('sv-SE');
+  const fmt = (n) => Math.round(n).toLocaleString('sv-SE');
+  hud.hi.textContent = fmt(high);
 
-  const fmt = (n) => n.toLocaleString('sv-SE');
+  const later = (fn, ms) => {
+    const id = setTimeout(fn, ms);
+    state.timers.push(id);
+    return id;
+  };
+
+  /* ---- Juice ---------------------------------------------------------- */
+
+  const shake = { power: 0 };
+  let hitStop = 0;
+  let fovPunch = 0;
+
+  function kick(power, stopMs = 0, fov = 0) {
+    shake.power = Math.max(shake.power, power);
+    hitStop = Math.max(hitStop, stopMs / 1000);
+    fovPunch = Math.max(fovPunch, fov);
+    if (navigator.vibrate) navigator.vibrate(Math.min(40, power * 26));
+  }
+
+  const projected = new THREE.Vector3();
+
+  /** Floating score number anchored to a world position. */
+  function popScore(text, world, cls = '') {
+    projected.copy(world).project(camera);
+    if (projected.z > 1) return;
+    const el = document.createElement('div');
+    el.className = `fg-pop ${cls}`;
+    el.textContent = text;
+    el.style.left = `${(projected.x * 0.5 + 0.5) * 100}%`;
+    el.style.top = `${(-projected.y * 0.5 + 0.5) * 100}%`;
+    hud.pops.appendChild(el);
+    later(() => el.remove(), 1100);
+  }
 
   function toast(msg, big = false) {
     hud.toast.textContent = msg;
@@ -475,85 +330,145 @@ export async function createFishing(container) {
     }, big ? 1700 : 1000);
   }
 
-  function addScore(n) {
-    state.score += n;
-    hud.score.textContent = fmt(state.score);
-  }
-
   function setPhaseLabel(txt) {
     hud.phase.textContent = txt;
     hud.phase.classList.toggle('show', !!txt);
+  }
+
+  function renderMult() {
+    const show = state.mult > 1 && (state.phase === 'drop' || state.phase === 'reel');
+    hud.mult.textContent = `×${state.mult.toFixed(1).replace(/\.0$/, '')}`;
+    hud.mult.classList.toggle('show', show);
+    hud.mult.classList.toggle('hot', state.mult >= 4);
+  }
+
+  function addScore(n, world, label) {
+    state.score += n;
+    hud.score.textContent = fmt(state.score);
+    hud.score.classList.remove('bump');
+    void hud.score.offsetWidth;
+    hud.score.classList.add('bump');
+    if (world) popScore(label || `+${fmt(n)}`, world);
   }
 
   function renderCast() {
     hud.cast.textContent = `KAST ${Math.min(state.castNo, CASTS_PER_GAME)}/${CASTS_PER_GAME}`;
   }
 
-  /* ------------------------------------------------------- phase control */
+  /* ---- Phases --------------------------------------------------------- */
 
   function startCast() {
     state.phase = 'drop';
     state.depth = 0;
-    state.dropSpeed = 6;
+    state.dropSpeed = 6.5;
     state.lureX = 0;
     state.targetX = 0;
     state.caught = [];
     state.combo = 0;
+    state.dodges = 0;
+    state.mult = 1;
+    state.tapChain = 0;
+    state.zone = -1;
     spawnFishSet();
-    sfx.splash();
-    setPhaseLabel('VÄJ FÖR FISKEN — djupare ner finns finare fångst');
-    setTimeout(() => setPhaseLabel(''), 2600);
+    sfx.splash(1.1);
+    emitBurst(burst, 1.9, 0.2, 0, 26, 5, 0.7);
+    setPhaseLabel('VÄJ FÖR FISKEN — djupare ner simmar det finare');
+    later(() => setPhaseLabel(''), 2600);
     renderCast();
+    renderMult();
   }
 
-  function hookAt(fish) {
-    // Hooked (or bottomed): the reel turns and now every fish counts
+  function onDodge(f) {
+    f.dodged = true;
+    state.dodges++;
+    state.mult = Math.min(10, 1 + state.dodges * 0.5);
+    sfx.dodge(state.dodges);
+    renderMult();
+    if (state.dodges % 4 === 0) popScore(`×${state.mult.toFixed(1)}`, f.mesh.position, 'mult');
+  }
+
+  function hookAt(fish, reason) {
     state.phase = 'reel';
     sfx.hook();
-    if (fish) catchOne(fish);
-    setPhaseLabel('VEVA! Fånga allt på vägen upp!');
-    setTimeout(() => setPhaseLabel(''), 2200);
-    if (navigator.vibrate) navigator.vibrate(30);
+    kick(1.1, 70, 5);
+    emitBurst(burst, state.lureX, -state.depth, 0, 22, 4.5, 0.5);
+    if (fish) catchOne(fish, true);
+    if (reason === 'bottom') {
+      const bonus = 1500 * state.mult;
+      addScore(bonus, lure.position, `BOTTEN +${fmt(bonus)}`);
+      state.mult = Math.min(12, state.mult + 2);
+      toast('Bottenkänning! Full multiplikator.', true);
+      sfx.legend();
+    } else if (reason === 'junk') {
+      toast(`${fish ? fish.sp.name : 'Skräp'} … inga poäng.`);
+      state.mult = 1;
+    }
+    renderMult();
+    setPhaseLabel('VEVA! Nu gäller det att träffa allt');
+    later(() => setPhaseLabel(''), 2200);
   }
 
-  function catchOne(f) {
+  function catchOne(f, first) {
     f.caught = true;
     state.combo++;
     state.caught.push(f);
-    addScore(f.sp.pts);
+    const pts = Math.round(f.sp.pts * state.mult);
+    if (!first) state.mult = Math.min(12, state.mult + 0.25);
+    addScore(pts, f.mesh.position, `${f.sp.name} +${fmt(pts)}`);
     sfx.catchFish(state.combo);
+    emitBurst(burst, f.mesh.position.x, f.mesh.position.y, f.mesh.position.z, 14, 3.4, 0.6);
+    renderMult();
     if (f.sp.rare) {
       sfx.legend();
-      toast('PEKKAGÄDDAN ÄR KROKAD!! +500', true);
+      toast('PEKKAGÄDDAN ÄR KROKAD!!', true);
+      kick(2.6, 120, 9);
+      emitBurst(burst, f.mesh.position.x, f.mesh.position.y, f.mesh.position.z, 60, 7, 1.2);
     } else {
-      toast(`${f.sp.name} +${f.sp.pts}`);
+      kick(0.5, 0, 0);
     }
-    if (navigator.vibrate) navigator.vibrate(15);
   }
 
   function startToss() {
     state.phase = 'toss';
+    hud.zone.classList.remove('show');
+    state.tapChain = 0;
     sfx.toss();
-    setPhaseLabel('TRYCK PÅ FISKEN — i tunnan för dubbelt!');
-    state.tossLeft = state.caught.length;
+    sfx.splash(0.8);
+    emitBurst(burst, state.lureX, 0.2, 0, 34, 6, 0.9);
+    kick(0.9, 0, 4);
     const n = state.caught.length;
+    state.tossLeft = n;
+    if (n === 0) {
+      setPhaseLabel('Tomt nät den här gången');
+      later(endCast, 1100);
+      return;
+    }
+    setPhaseLabel('TRYCK PÅ FISKEN — i tunnan för dubbelt');
+    // Cut straight to the above-water framing: watching this from under the
+    // surface was the single worst thing about the phase.
+    camera.position.set(boat.position.x, 3.6, 15.5);
+    lookAt.set(boat.position.x, 2.7, 0.4);
+    camera.lookAt(lookAt);
     state.caught.forEach((f, i) => {
       const spread = n > 1 ? (i / (n - 1)) * 2 - 1 : 0;
       f.air = {
-        x: boat.position.x + spread * 1.5,
-        y: 1.2,
-        vx: spread * 4.2 + (Math.random() - 0.5) * 1.5,
-        vy: 13 + Math.random() * 4,
+        x: boat.position.x + spread * 1.3,
+        y: 0.6,
+        z: 1.4,
+        vx: spread * 2.3 + (Math.random() - 0.5) * 0.9,
+        vy: 11 + Math.random() * 3.2,
+        spin: (Math.random() - 0.5) * 8,
         done: false
       };
       f.mesh.visible = true;
-      f.mesh.scale.setScalar(f.sp.size * 0.85);
+      // Bigger in the air than in the water — they have to be thumb-sized
+      f.mesh.scale.setScalar(f.sp.size * 1.35);
     });
-    if (n === 0) setTimeout(endCast, 900);
   }
 
   function endCast() {
     setPhaseLabel('');
+    hud.mult.classList.remove('show');
     if (state.castNo >= CASTS_PER_GAME) {
       gameOver();
       return;
@@ -562,9 +477,9 @@ export async function createFishing(container) {
     state.phase = 'between';
     renderCast();
     toast(`Kast ${state.castNo} av ${CASTS_PER_GAME}`, true);
-    setTimeout(() => {
+    later(() => {
       if (state.phase === 'between') startCast();
-    }, 1400);
+    }, 1500);
   }
 
   function gameOver() {
@@ -573,7 +488,7 @@ export async function createFishing(container) {
     if (isHigh) {
       high = state.score;
       try {
-        localStorage.setItem(HIGHSCORE_KEY, String(high));
+        localStorage.setItem(HIGHSCORE_KEY, String(Math.round(high)));
       } catch (e) {
         /* private mode */
       }
@@ -583,9 +498,12 @@ export async function createFishing(container) {
     hud.title.textContent = isHigh ? 'Nytt rekord!' : 'Fisket är slut';
     hud.text.textContent = isHigh
       ? 'Största fångsten hittills på den här enheten. Petri heder!'
-      : 'Tre kast, sen är det kaffe och rökt sik. En tur till?';
+      : 'Sen är det kaffe och rökt sik vid bryggan. En tur till?';
+    hud.steps.hidden = true;
     hud.scoreline.hidden = false;
     hud.scoreline.innerHTML = `<span>${fmt(state.score)}</span><small>poäng · rekord ${fmt(high)}</small>`;
+    hud.catchlist.hidden = false;
+    hud.catchlist.innerHTML = `<b>Djupaste kast</b><span>${Math.round(state.deepest)} m</span>`;
     hud.start.textContent = 'Fiska igen';
     hud.overlay.classList.add('show');
   }
@@ -594,36 +512,42 @@ export async function createFishing(container) {
     sfx.resume();
     state.score = 0;
     state.castNo = 1;
+    state.deepest = 0;
     hud.score.textContent = '0';
     hud.scoreline.hidden = true;
+    hud.catchlist.hidden = true;
+    hud.steps.hidden = false;
     hud.overlay.classList.remove('show');
     startCast();
   }
 
-  /* -------------------------------------------------------------- input */
+  /* ---- Input ---------------------------------------------------------- */
 
   let dragging = false;
+  const REACH = 9;
 
-  function pointerToX(e) {
+  function pointerToNdc(e) {
     const rect = canvasHost.getBoundingClientRect();
-    return ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    return {
+      x: ((e.clientX - rect.left) / rect.width) * 2 - 1,
+      y: -(((e.clientY - rect.top) / rect.height) * 2 - 1)
+    };
   }
 
   function onPointerDown(e) {
     sfx.resume();
     if (e.target.closest('.pb-overlay, .pb-mute')) return;
-
     if (state.phase === 'toss') {
       tryTapFish(e);
       return;
     }
     dragging = true;
-    state.targetX = pointerToX(e) * 9;
+    state.targetX = pointerToNdc(e).x * REACH;
   }
 
   function onPointerMove(e) {
     if (!dragging) return;
-    state.targetX = pointerToX(e) * 9;
+    state.targetX = pointerToNdc(e).x * REACH;
   }
 
   function onPointerUp() {
@@ -632,44 +556,59 @@ export async function createFishing(container) {
 
   function onKeyDown(e) {
     const k = e.key.toLowerCase();
-    if (k === 'arrowleft' || k === 'a') state.targetX = Math.max(-9, state.targetX - 2.4);
-    else if (k === 'arrowright' || k === 'd') state.targetX = Math.min(9, state.targetX + 2.4);
-    else if (k === ' ' && (state.phase === 'idle' || state.phase === 'over')) {
+    if (k === 'arrowleft' || k === 'a') state.targetX = Math.max(-REACH, state.targetX - 2.4);
+    else if (k === 'arrowright' || k === 'd') state.targetX = Math.min(REACH, state.targetX + 2.4);
+    else if (k === ' ' && (state.phase === 'idle' || state.phase === 'over' || state.phase === 'between')) {
       e.preventDefault();
       startGame();
     }
   }
 
-  /* Tap detection in the toss phase: closest airborne fish in screen space */
   const ndc = new THREE.Vector3();
 
   function tryTapFish(e) {
-    const rect = canvasHost.getBoundingClientRect();
-    const tx = ((e.clientX - rect.left) / rect.width) * 2 - 1;
-    const ty = -(((e.clientY - rect.top) / rect.height) * 2 - 1);
+    const p = pointerToNdc(e);
     let bestF = null;
-    let bestD = 0.16; // generous thumb radius in NDC
+    let bestD = 0.17; // a generous thumb in NDC
     state.caught.forEach((f) => {
       if (!f.air || f.air.done) return;
       ndc.copy(f.mesh.position).project(camera);
-      const d = Math.hypot(ndc.x - tx, ndc.y - ty);
+      const d = Math.hypot(ndc.x - p.x, ndc.y - p.y);
       if (d < bestD) {
         bestD = d;
         bestF = f;
       }
     });
-    if (bestF) {
-      bestF.air.done = 'hit';
-      state.tossLeft--;
-      addScore(bestF.sp.pts); // doubles the fish
-      sfx.tap(state.caught.length - state.tossLeft);
-      toast(`${bestF.sp.name} i tunnan! +${bestF.sp.pts}`);
-      // fly to the barrel
-      bestF.air.vx = (boat.position.x + 2.6 - bestF.mesh.position.x) * 3;
-      bestF.air.vy = 7;
-      if (navigator.vibrate) navigator.vibrate(12);
-      if (state.tossLeft <= 0) setTimeout(endCast, 700);
+    if (!bestF) {
+      state.tapChain = 0;
+      return;
     }
+    state.tapChain++;
+    const chainBonus = 1 + (state.tapChain - 1) * 0.25;
+    const pts = Math.round(bestF.sp.pts * state.mult * chainBonus);
+    bestF.air.done = 'hit';
+    state.tossLeft--;
+    addScore(pts, bestF.mesh.position, `+${fmt(pts)}`);
+    sfx.tap(state.tapChain);
+    emitBurst(burst, bestF.mesh.position.x, bestF.mesh.position.y, bestF.mesh.position.z, 16, 4, 0.5);
+    kick(0.5, 0, 2);
+    // Arc it into the tunna
+    const target = boat.position.x + 1.75;
+    bestF.air.vx = (target - bestF.mesh.position.x) * 2.2;
+    bestF.air.vy = 7.5;
+    if (state.tossLeft <= 0) finishToss();
+  }
+
+  function finishToss() {
+    const all = state.caught.length > 0 && state.caught.every((f) => f.air && f.air.done === 'hit');
+    if (all && state.caught.length > 1) {
+      const bonus = Math.round(2000 * state.mult);
+      toast(`PERFEKT KAST! +${fmt(bonus)}`, true);
+      addScore(bonus);
+      sfx.legend();
+      kick(1.6, 90, 6);
+    }
+    later(endCast, 750);
   }
 
   canvasHost.addEventListener('pointerdown', onPointerDown);
@@ -682,7 +621,9 @@ export async function createFishing(container) {
     hud.mute.classList.toggle('off', sfx.muted);
   });
 
-  /* -------------------------------------------------------------- sizing */
+  /* ---- Sizing --------------------------------------------------------- */
+
+  let baseFov = 56;
 
   function resize() {
     const rect = canvasHost.getBoundingClientRect();
@@ -690,7 +631,7 @@ export async function createFishing(container) {
     const h = Math.max(1, Math.floor(rect.height));
     renderer.setSize(w, h, false);
     camera.aspect = w / h;
-    camera.fov = camera.aspect < 0.7 ? 62 : 55;
+    baseFov = camera.aspect < 0.7 ? 64 : 56;
     camera.updateProjectionMatrix();
   }
 
@@ -698,168 +639,316 @@ export async function createFishing(container) {
   ro.observe(canvasHost);
   resize();
 
-  /* ---------------------------------------------------------------- loop */
+  /* ---- Loop ----------------------------------------------------------- */
 
   let raf = 0;
   let last = performance.now();
   let running = true;
-  const camTarget = new THREE.Vector3(0, 2, 0);
+  const camGoal = new THREE.Vector3();
+  const lookGoal = new THREE.Vector3();
+  const lookAt = new THREE.Vector3(0, 1.5, 0);
   const tmpColor = new THREE.Color();
+  const rodTip = new THREE.Vector3();
+  const snowBox = snow.userData.box;
+
+  function updateFish(dt, t) {
+    const focusY = -state.depth;
+    fishes.forEach((f) => {
+      if (f.caught) return;
+      const m = f.mesh;
+      if (Math.abs(m.position.y - focusY) > 26) return; // out of sight, skip
+      m.position.x += f.dir * f.speed * dt;
+      m.position.y += Math.sin(t * 1.6 + f.phase) * f.bob * dt;
+      if (f.junk) {
+        m.rotation.z = Math.sin(t * 0.7 + f.phase) * 0.25;
+        m.rotation.y += dt * 0.3;
+      } else {
+        swim(m, t + f.phase, f.speed, f.deco ? 0.7 : 1);
+      }
+      if (f.dir > 0 && m.position.x > 18) m.position.x = -18;
+      else if (f.dir < 0 && m.position.x < -18) m.position.x = 18;
+    });
+  }
+
+  function collide(reeling) {
+    const y = -state.depth;
+    for (const f of fishes) {
+      if (f.caught || f.deco) continue;
+      const m = f.mesh;
+      const { size } = f.sp;
+      const dx = m.position.x - state.lureX;
+      const dy = m.position.y - y;
+      const dz = m.position.z;
+      const rx = (reeling ? 1.15 : 0.95) * size + 0.32;
+      const ry = (reeling ? 0.85 : 0.62) * size + 0.3;
+      if (Math.abs(dx) < rx && Math.abs(dy) < ry && Math.abs(dz) < 1.0) {
+        if (reeling) {
+          if (f.junk) continue;
+          catchOne(f, false);
+        } else if (f.junk) {
+          f.caught = true;
+          f.mesh.visible = false;
+          sfx.junk();
+          hookAt(null, 'junk');
+          return;
+        } else {
+          hookAt(f, 'fish');
+          return;
+        }
+      } else if (!reeling && !f.dodged && !f.junk && dy > ry + 0.1 && dy < 3.2 && Math.abs(dx) < 3.4) {
+        onDodge(f); // slipped past above us
+      }
+    }
+  }
+
+  function updateLine(dt) {
+    const { nodes, segments } = line.userData;
+    boat.userData.rod.getWorldPosition(rodTip);
+    rodTip.x += 2.6;
+    rodTip.y += 1.1;
+    nodes[0].copy(rodTip);
+    nodes[segments].set(state.lureX, -state.depth + 0.22, 0);
+    for (let pass = 0; pass < 2; pass++) {
+      for (let i = 1; i < segments; i++) {
+        const prev = nodes[i - 1];
+        const next = nodes[i + 1];
+        const n = nodes[i];
+        n.x += ((prev.x + next.x) * 0.5 - n.x) * Math.min(1, dt * 26);
+        n.y += ((prev.y + next.y) * 0.5 - n.y) * Math.min(1, dt * 26);
+        n.z += ((prev.z + next.z) * 0.5 - n.z) * Math.min(1, dt * 26);
+      }
+    }
+    const arr = line.geometry.attributes.position.array;
+    for (let i = 0; i <= segments; i++) {
+      arr[i * 3] = nodes[i].x;
+      arr[i * 3 + 1] = nodes[i].y;
+      arr[i * 3 + 2] = nodes[i].z;
+    }
+    line.geometry.attributes.position.needsUpdate = true;
+  }
+
+  function updateZone() {
+    let z = 0;
+    for (let i = 0; i < ZONES.length; i++) if (state.depth >= ZONES[i].at) z = i;
+    if (z === state.zone) return;
+    state.zone = z;
+    hud.zone.textContent = ZONES[z].name;
+    hud.zone.classList.remove('show');
+    void hud.zone.offsetWidth;
+    hud.zone.classList.add('show');
+    if (z > 0) sfx.zone();
+    later(() => hud.zone.classList.remove('show'), 1800);
+  }
+
+  function updateCamera(dt) {
+    const under = state.depth > 0.6;
+    if (state.phase === 'idle' || state.phase === 'over') {
+      camGoal.set(-3.2, 3.0, 13.5);
+      lookGoal.set(0.6, 1.5, 0);
+    } else if (state.phase === 'toss') {
+      camGoal.set(boat.position.x, 3.6, 15.5);
+      lookGoal.set(boat.position.x, 2.7, 0.4);
+    } else if (under) {
+      const lead = (state.targetX - state.lureX) * 0.25;
+      camGoal.set(state.lureX * 0.55 + lead, -state.depth + 2.6, 11.5);
+      lookGoal.set(state.lureX * 0.75, -state.depth + 0.2, 0);
+    } else {
+      camGoal.set(state.lureX * 0.4, 2.8, 13);
+      lookGoal.set(state.lureX * 0.5, 0.6, 0);
+    }
+    const s = Math.min(1, dt * 3.2);
+    camera.position.lerp(camGoal, s);
+    lookAt.lerp(lookGoal, Math.min(1, dt * 4.5));
+
+    if (shake.power > 0.001) {
+      shake.power = Math.max(0, shake.power - dt * 4.2);
+      const a = shake.power * 0.22;
+      camera.position.x += (Math.random() - 0.5) * a;
+      camera.position.y += (Math.random() - 0.5) * a;
+    }
+    camera.lookAt(lookAt);
+
+    if (fovPunch > 0.01) {
+      fovPunch = Math.max(0, fovPunch - dt * 26);
+      camera.fov = baseFov + fovPunch;
+      camera.updateProjectionMatrix();
+    } else if (Math.abs(camera.fov - baseFov) > 0.01) {
+      camera.fov = baseFov;
+      camera.updateProjectionMatrix();
+    }
+  }
+
+  function updateAtmosphere(dt) {
+    const d = Math.max(0, state.depth);
+    const k = Math.min(1, d / 52);
+    gradient(WATER_STOPS, d, tmpColor);
+    const above = state.depth < 0.4 && (state.phase === 'idle' || state.phase === 'over' || state.phase === 'toss');
+    scene.background.lerp(above ? tmpColor.set(0x8fb9cf) : tmpColor, Math.min(1, dt * 6));
+    scene.fog.color.copy(scene.background);
+    scene.fog.density = above ? 0.0009 : 0.013 + k * 0.035;
+
+    // The sky must never bleed through from below the waterline — the dome
+    // is hard-gated on the camera, not just faded.
+    const eyeAbove = camera.position.y > -0.6;
+    sky.uniforms.uOpacity.value +=
+      ((eyeAbove ? 1 : 0) - sky.uniforms.uOpacity.value) * Math.min(1, dt * 10);
+    sky.dome.visible = eyeAbove && sky.uniforms.uOpacity.value > 0.02;
+    shore.visible = sky.dome.visible;
+
+    water.uniforms.uFogColor.value.copy(scene.fog.color);
+    water.uniforms.uFogDensity.value = scene.fog.density;
+    water.uniforms.uDeepTint.value.copy(scene.background);
+    water.uniforms.uCausticStrength.value = 1 - k * 0.55;
+
+    hemi.intensity = 1.15 - k * 0.78;
+    sun.intensity = 1.7 - k * 1.45;
+    lure.userData.glow.intensity = 0.7 + k * 2.4;
+
+    shafts.material.opacity = Math.max(0, 0.55 - k * 1.5);
+    shafts.visible = shafts.material.opacity > 0.01;
+
+    // Marine snow belongs in the water, not in the sky over the boat
+    snow.visible = camera.position.y < -1.2;
+    snow.material.opacity = 0.22 + k * 0.5;
+  }
+
+  function updateSnow() {
+    const arr = snow.geometry.attributes.position.array;
+    const cx = camera.position.x;
+    const cy = camera.position.y;
+    const half = snowBox / 2;
+    for (let i = 0; i < snow.userData.count; i++) {
+      let x = arr[i * 3] - cx;
+      let y = arr[i * 3 + 1] - cy;
+      if (x > half) x -= snowBox; else if (x < -half) x += snowBox;
+      if (y > half) y -= snowBox; else if (y < -half) y += snowBox;
+      arr[i * 3] = cx + x;
+      arr[i * 3 + 1] = cy + y;
+    }
+    snow.geometry.attributes.position.needsUpdate = true;
+  }
 
   function tick(now) {
     raf = requestAnimationFrame(tick);
-    const dt = Math.min(0.05, (now - last) / 1000);
+    let dt = Math.min(0.05, (now - last) / 1000);
     last = now;
     if (!running) return;
     const t = now / 1000;
 
-    /* Surface waves */
-    for (let i = 0; i < surfPos.count; i++) {
-      const x = surfBase[i * 3];
-      const z = surfBase[i * 3 + 2];
-      surfPos.setY(i, Math.sin(x * 0.5 + t * 1.3) * 0.22 + Math.cos(z * 0.7 + t * 0.9) * 0.18);
+    if (hitStop > 0) {
+      hitStop -= dt;
+      dt *= 0.12;
     }
-    surfPos.needsUpdate = true;
-    surface.geometry.computeVertexNormals();
+    if (state.phase === 'toss') dt *= 0.8; // a touch of slow-mo to aim thumbs
 
-    boat.position.y = 0.35 + Math.sin(t * 1.1) * 0.12;
-    boat.rotation.z = Math.sin(t * 0.9) * 0.03;
+    water.uniforms.uTime.value = t;
+    boat.position.y = -0.08 + Math.sin(t * 1.05) * 0.12;
+    boat.rotation.z = Math.sin(t * 0.9) * 0.035;
+    boat.rotation.x = Math.sin(t * 0.7 + 1.1) * 0.02;
+    boat.userData.foam.position.set(boat.position.x, 0.05, 0);
+    boat.userData.foam.material.opacity = 0.06 + Math.sin(t * 2.2) * 0.02;
 
-    weeds.forEach((w, i) => {
-      w.rotation.x = Math.sin(t * 0.8 + i) * 0.12;
-    });
-    shafts.forEach((s, i) => {
-      s.material.opacity = 0.06 + Math.sin(t * 0.5 + i * 1.7) * 0.045;
-    });
+    // The rod loads up while the reel is turning
+    const load = state.phase === 'reel' ? 0.55 : state.phase === 'drop' ? 0.2 : 0;
+    boat.userData.rod.rotation.z += (0.5 - load - boat.userData.rod.rotation.z) * Math.min(1, dt * 5);
+    boat.userData.arms.rotation.z = state.phase === 'reel' ? Math.sin(t * 9) * 0.06 : 0;
 
-    /* Fish swim */
-    fishes.forEach((f) => {
-      if (f.caught) return;
-      f.mesh.position.x += f.dir * f.speed * dt;
-      f.mesh.position.y += Math.sin(t * 2 + f.phase) * 0.15 * dt;
-      f.userDataWiggle = Math.sin(t * 8 + f.phase) * 0.3;
-      f.mesh.userData.tail.rotation.y = f.userDataWiggle;
-      if (f.dir > 0 && f.mesh.position.x > 16) {
-        f.mesh.position.x = -16;
-      } else if (f.dir < 0 && f.mesh.position.x < -16) {
-        f.mesh.position.x = 16;
-      }
+    seabed.userData.weeds.forEach((w) => {
+      w.rotation.z = Math.sin(t * 0.75 + w.userData.phase) * 0.16;
     });
 
-    /* Phases */
+    updateFish(dt, t);
+
     if (state.phase === 'drop') {
-      state.dropSpeed = Math.min(15, state.dropSpeed + dt * 1.6);
+      state.dropSpeed = Math.min(15.5, state.dropSpeed + dt * 1.7);
       state.depth += state.dropSpeed * dt;
-      state.lureX += (state.targetX - state.lureX) * Math.min(1, dt * 6);
-      sfx.reel();
-
+      state.lureX += (state.targetX - state.lureX) * Math.min(1, dt * 6.5);
+      state.deepest = Math.max(state.deepest, state.depth);
+      sfx.reelTick(state.dropSpeed);
+      if (Math.random() < dt * 7) {
+        emitBurst(burst, state.lureX, -state.depth, 0, 1, 0.35, 0.25);
+      }
+      updateZone();
       if (state.depth >= BOTTOM) {
         state.depth = BOTTOM;
-        toast('Botten! Nu vevar vi.', true);
-        hookAt(null);
+        hookAt(null, 'bottom');
       } else {
-        // Touching a fish on the way down hooks it
-        for (const f of fishes) {
-          if (f.caught) continue;
-          const dx = f.mesh.position.x - state.lureX;
-          const dy = f.mesh.position.y + state.depth;
-          if (Math.abs(dx) < 0.9 * f.sp.size + 0.3 && Math.abs(dy) < 0.7 * f.sp.size + 0.3) {
-            hookAt(f);
-            break;
-          }
-        }
+        collide(false);
       }
     } else if (state.phase === 'reel') {
-      state.depth -= 16 * dt;
-      state.lureX += (state.targetX - state.lureX) * Math.min(1, dt * 7);
-
-      for (const f of fishes) {
-        if (f.caught) continue;
-        const dx = f.mesh.position.x - state.lureX;
-        const dy = f.mesh.position.y + state.depth;
-        if (Math.abs(dx) < 1.1 * f.sp.size + 0.35 && Math.abs(dy) < 0.9 * f.sp.size + 0.35) {
-          catchOne(f);
-        }
-      }
-
+      state.depth -= 16.5 * dt;
+      state.lureX += (state.targetX - state.lureX) * Math.min(1, dt * 7.5);
+      sfx.reelTick(18);
+      collide(true);
       if (state.depth <= 0) {
         state.depth = 0;
         startToss();
       }
     } else if (state.phase === 'toss') {
       state.caught.forEach((f) => {
-        if (!f.air) return;
-        if (f.air.done === 'hit' && f.mesh.position.y < 1.0) {
+        const { air } = f;
+        if (!air || air.done === true) return;
+        if (air.done === 'hit' && f.mesh.position.y < 1.15 &&
+            Math.abs(f.mesh.position.x - (boat.position.x + 1.75)) < 1.1) {
           f.mesh.visible = false;
-          f.air = { done: true };
+          air.done = true;
+          sfx.plopp();
           return;
         }
-        if (f.air.done === true) return;
-        f.air.vy -= 20 * dt;
-        f.air.x += f.air.vx * dt;
-        f.air.y += f.air.vy * dt;
-        f.mesh.position.set(f.air.x, f.air.y, 1.5);
-        f.mesh.rotation.z += dt * 7;
-        if (f.air.y < -0.4 && f.air.done !== 'hit') {
-          // splashed back — lost the bonus
-          f.air.done = true;
+        air.vy -= 20 * dt;
+        air.x += air.vx * dt;
+        air.y += air.vy * dt;
+        f.mesh.position.set(air.x, air.y, air.z);
+        f.mesh.rotation.z += air.spin * dt;
+        f.mesh.rotation.y = 0;
+        swim(f.mesh, t * 2.2, 6, 1.4);
+        if (air.y < -0.5 && air.done !== 'hit') {
+          air.done = true;
           f.mesh.visible = false;
           state.tossLeft--;
+          state.tapChain = 0;
           sfx.miss();
-          if (state.tossLeft <= 0) setTimeout(endCast, 600);
+          sfx.splash(0.5);
+          emitBurst(burst, air.x, 0.1, air.z, 12, 3.4, 0.5);
+          if (state.tossLeft <= 0) finishToss();
         }
       });
     }
 
-    /* Lure follows */
+    /* Lure, line and the string of fish following it */
     const lureY = -state.depth;
     lure.position.set(state.lureX, lureY, 0);
-    lure.rotation.z = (state.targetX - state.lureX) * -0.08;
+    lure.rotation.z = (state.targetX - state.lureX) * -0.06;
+    lure.userData.spinner.rotation.x = t * 12;
     lure.visible = state.phase === 'drop' || state.phase === 'reel';
     line.visible = lure.visible;
-    if (lure.visible) {
-      const pts = line.geometry.attributes.position.array;
-      pts[0] = boat.position.x + 1.6;
-      pts[1] = boat.position.y + 1.4;
-      pts[2] = 0;
-      pts[3] = state.lureX;
-      pts[4] = lureY + 0.3;
-      pts[5] = 0;
-      line.geometry.attributes.position.needsUpdate = true;
-    }
+    if (lure.visible) updateLine(dt);
 
-    /* Caught fish trail behind the lure during the reel */
     if (state.phase === 'reel' || state.phase === 'drop') {
+      // Strung below the lure, nose-up, each one lagging a little more than
+      // the last so the whole catch swings like a real stringer.
       state.caught.forEach((f, i) => {
         f.mesh.visible = true;
-        f.mesh.position.x += (state.lureX - f.mesh.position.x) * Math.min(1, dt * 8);
-        f.mesh.position.y = lureY - 0.9 - i * 0.75;
-        f.mesh.position.z = 0.2;
-        f.mesh.rotation.z = Math.PI / 2 + Math.sin(t * 6 + i) * 0.2;
+        const lag = Math.min(1, dt * (6.5 - Math.min(4, i * 0.5)));
+        const sway = Math.sin(t * 2.2 + i * 0.8) * 0.28;
+        f.mesh.position.x += (state.lureX + sway - f.mesh.position.x) * lag;
+        f.mesh.position.y += (lureY - 1.15 - i * 1.35 - f.mesh.position.y) * Math.min(1, dt * 9);
+        f.mesh.position.z += (0.35 - f.mesh.position.z) * Math.min(1, dt * 6);
+        f.mesh.rotation.z = Math.PI / 2 + Math.sin(t * 4 + i) * 0.2;
+        f.mesh.rotation.y = 0.5;
+        f.mesh.scale.setScalar(f.sp.size * 0.85);
+        swim(f.mesh, t * 1.6 + i, 3, 1.6);
       });
     }
 
-    /* Camera + atmosphere by depth */
-    const focus = state.phase === 'toss' ? 4 : Math.max(2 - state.depth, -state.depth + 3.5);
-    camTarget.set(state.lureX * 0.45, state.phase === 'idle' || state.phase === 'over' ? 2 : focus, 0);
-    camera.position.x += (camTarget.x - camera.position.x) * Math.min(1, dt * 3);
-    camera.position.y += (camTarget.y + 1.5 - camera.position.y) * Math.min(1, dt * 4);
-    camera.lookAt(camTarget.x, camTarget.y, 0);
-
-    const k = Math.min(1, state.depth / 45);
-    if (state.depth > 1) {
-      tmpColor.copy(SURF).lerp(DEEP, k);
-    } else {
-      tmpColor.copy(SKY);
-    }
-    scene.background.lerp(tmpColor, Math.min(1, dt * 3));
-    scene.fog.color.copy(scene.background);
-    scene.fog.density = 0.016 + k * 0.03;
-    hemi.intensity = 1.0 - k * 0.62;
-    sun.intensity = 1.4 - k * 1.0;
+    // Underwater everything drifts up; in the air over the boat it falls.
+    updateBurst(burst, dt, state.phase === 'toss' ? -7 : 1.4);
+    updateCamera(dt);
+    updateAtmosphere(dt);
+    updateSnow();
+    sfx.setDepth(state.depth, BOTTOM);
 
     hud.depth.textContent = `${Math.round(state.depth)} m`;
-
     renderer.render(scene, camera);
   }
 
@@ -878,15 +967,17 @@ export async function createFishing(container) {
   /* Deterministic hooks for automated tests */
   window.__ppFiske = {
     state,
+    scene,
+    camera,
     startGame,
     forceHook() {
-      if (state.phase === 'drop') hookAt(null);
+      if (state.phase === 'drop') hookAt(null, 'fish');
     },
     forceCatch(n = 3) {
       fishes
-        .filter((f) => !f.caught)
+        .filter((f) => !f.caught && !f.deco && !f.junk)
         .slice(0, n)
-        .forEach((f) => catchOne(f));
+        .forEach((f) => catchOne(f, false));
     },
     toSurface() {
       state.depth = 0.01;
@@ -899,15 +990,22 @@ export async function createFishing(container) {
         if (f.air && !f.air.done) {
           f.air.done = 'hit';
           state.tossLeft--;
-          addScore(f.sp.pts);
+          addScore(Math.round(f.sp.pts * state.mult));
         }
       });
-      if (state.tossLeft <= 0) setTimeout(endCast, 100);
+      if (state.tossLeft <= 0) finishToss();
     },
-    fishes
+    fishes,
+    info() {
+      return {
+        drawCalls: renderer.info.render.calls,
+        triangles: renderer.info.render.triangles,
+        fish: fishes.length
+      };
+    }
   };
 
-  /* ---- Teardown ---- */
+  /* ---- Teardown ------------------------------------------------------- */
   function destroy() {
     cancelAnimationFrame(raf);
     running = false;
@@ -918,8 +1016,10 @@ export async function createFishing(container) {
     window.removeEventListener('pointerup', onPointerUp);
     window.removeEventListener('keydown', onKeyDown);
     clearTimeout(state.lastToast);
+    state.timers.forEach(clearTimeout);
     delete window.__ppFiske;
 
+    clearFish();
     scene.traverse((o) => {
       if (o.geometry) o.geometry.dispose();
       if (o.material) {
@@ -927,6 +1027,9 @@ export async function createFishing(container) {
         mats.forEach((m) => m.dispose());
       }
     });
+    disposeAssets();
+    caustics.dispose();
+    spark.dispose();
     renderer.dispose();
     renderer.forceContextLoss?.();
     if (sfx.ctx) sfx.ctx.close();
@@ -937,3 +1040,6 @@ export async function createFishing(container) {
 }
 
 export default createFishing;
+
+/* Species and junk tables are exported for the tests and the README. */
+export { SPECIES, JUNK };

--- a/src/games/fishing/index.js
+++ b/src/games/fishing/index.js
@@ -293,6 +293,12 @@ export async function createFishing(container) {
     return id;
   };
 
+  /* Camera scratch vectors — declared up here because startToss() cuts the
+     camera directly and runs before the loop section. */
+  const camGoal = new THREE.Vector3();
+  const lookGoal = new THREE.Vector3();
+  const lookAt = new THREE.Vector3(0, 1.5, 0);
+
   /* ---- Juice ---------------------------------------------------------- */
 
   const shake = { power: 0 };
@@ -644,9 +650,6 @@ export async function createFishing(container) {
   let raf = 0;
   let last = performance.now();
   let running = true;
-  const camGoal = new THREE.Vector3();
-  const lookGoal = new THREE.Vector3();
-  const lookAt = new THREE.Vector3(0, 1.5, 0);
   const tmpColor = new THREE.Color();
   const rodTip = new THREE.Vector3();
   const snowBox = snow.userData.box;

--- a/src/games/fishing/index.js
+++ b/src/games/fishing/index.js
@@ -1,0 +1,939 @@
+/**
+ * Pekkas Fiske — the 2024 competition as a Three.js fishing game.
+ *
+ * The loop is borrowed from the most loved mobile fishing game there is:
+ * steer the lure PAST the fish on the way down (deeper = better fish),
+ * hook one and catch everything you can on the way up, then the whole
+ * stringer is flung into the air and every fish you TAP lands in the
+ * tunna for double points. Three casts per game.
+ *
+ * Everything is procedural: low-poly fish, a rowing boat on a midnight-sun
+ * lake, depth-graded water and synthesized sound. The only download is
+ * Three.js itself.
+ */
+
+import * as THREE from 'three';
+
+const CASTS_PER_GAME = 3;
+const BOTTOM = 60; // metres — Själevadsfjärden runs deep
+const HIGHSCORE_KEY = 'pp-fiske-highscore';
+
+/* ---------------------------------------------------------------- species */
+
+const SPECIES = [
+  { id: 'mort', name: 'Mört', pts: 10, min: 2, max: 16, size: 0.55, color: 0xb9c4d6, belly: 0xe8edf5, speed: 2.6 },
+  { id: 'abborre', name: 'Abborre', pts: 25, min: 5, max: 30, size: 0.7, color: 0x5f8f5a, belly: 0xd8e9c8, speed: 3.1 },
+  { id: 'sik', name: 'Sik', pts: 40, min: 14, max: 42, size: 0.8, color: 0x9fb4c8, belly: 0xeef4fa, speed: 3.4 },
+  { id: 'gadda', name: 'Gädda', pts: 80, min: 20, max: 52, size: 1.25, color: 0x4a6b3f, belly: 0xcfe0b8, speed: 3.9 },
+  { id: 'lax', name: 'Lax', pts: 150, min: 34, max: 58, size: 1.05, color: 0x8a92b8, belly: 0xf3c9b8, speed: 4.6 },
+  { id: 'pekka', name: 'PEKKAGÄDDAN', pts: 500, min: 50, max: 59, size: 1.9, color: 0xf2c14e, belly: 0xfff3cf, speed: 5.2, rare: true }
+];
+
+/* ------------------------------------------------------------------ audio */
+
+class Sfx {
+  constructor() {
+    this.ctx = null;
+    this.muted = false;
+  }
+
+  resume() {
+    if (!this.ctx) {
+      const AC = window.AudioContext || window.webkitAudioContext;
+      if (!AC) return;
+      this.ctx = new AC();
+      this.master = this.ctx.createGain();
+      this.master.gain.value = 0.3;
+      this.master.connect(this.ctx.destination);
+    }
+    if (this.ctx.state === 'suspended') this.ctx.resume();
+  }
+
+  tone(freq, dur, type = 'sine', gain = 0.5, sweep = 0) {
+    if (!this.ctx || this.muted) return;
+    const t = this.ctx.currentTime;
+    const osc = this.ctx.createOscillator();
+    const env = this.ctx.createGain();
+    osc.type = type;
+    osc.frequency.setValueAtTime(freq, t);
+    if (sweep) osc.frequency.exponentialRampToValueAtTime(Math.max(30, freq + sweep), t + dur);
+    env.gain.setValueAtTime(0.0001, t);
+    env.gain.exponentialRampToValueAtTime(gain, t + 0.008);
+    env.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+    osc.connect(env).connect(this.master);
+    osc.start(t);
+    osc.stop(t + dur + 0.02);
+  }
+
+  noise(dur, gain = 0.4, freq = 800) {
+    if (!this.ctx || this.muted) return;
+    const t = this.ctx.currentTime;
+    const n = Math.floor(this.ctx.sampleRate * dur);
+    const buf = this.ctx.createBuffer(1, n, this.ctx.sampleRate);
+    const data = buf.getChannelData(0);
+    for (let i = 0; i < n; i++) data[i] = (Math.random() * 2 - 1) * (1 - i / n);
+    const src = this.ctx.createBufferSource();
+    src.buffer = buf;
+    const filt = this.ctx.createBiquadFilter();
+    filt.type = 'bandpass';
+    filt.frequency.value = freq;
+    const env = this.ctx.createGain();
+    env.gain.value = gain;
+    src.connect(filt).connect(env).connect(this.master);
+    src.start(t);
+  }
+
+  splash() { this.noise(0.35, 0.5, 500); this.tone(180, 0.25, 'sine', 0.3, -80); }
+  plopp() { this.tone(300, 0.09, 'sine', 0.5, -140); }
+  hook() { this.tone(700, 0.09, 'square', 0.4, 300); this.noise(0.08, 0.3, 1800); }
+  catchFish(n) { this.tone(420 * 1.12 ** Math.min(n, 10), 0.1, 'triangle', 0.5, 120); }
+  reel() { this.tone(1400, 0.025, 'square', 0.12); }
+  toss() { this.noise(0.3, 0.4, 700); this.tone(220, 0.3, 'sawtooth', 0.3, 400); }
+  tap(n) { this.tone(520 * 1.12 ** Math.min(n, 8), 0.12, 'square', 0.45, 200); }
+  miss() { this.tone(200, 0.2, 'sine', 0.3, -90); }
+  legend() {
+    [0, 110, 220, 330, 480].forEach((d, i) =>
+      setTimeout(() => this.tone(392 * 2 ** (i / 4), 0.22, 'triangle', 0.5), d));
+  }
+  fanfare() {
+    [0, 90, 180, 340].forEach((d, i) =>
+      setTimeout(() => this.tone(523 * (1 + i * 0.25), 0.2, 'triangle', 0.5), d));
+  }
+}
+
+/* ------------------------------------------------------------------- HUD */
+
+function buildHud(root) {
+  root.innerHTML = `
+    <div class="pb-hud">
+      <div class="pb-top">
+        <div class="pb-score-wrap">
+          <div class="pb-score" id="fg-score">0</div>
+          <div class="pb-hi">REKORD <span id="fg-hi">0</span></div>
+        </div>
+        <div class="pb-meta">
+          <div class="fg-depth" id="fg-depth">0 m</div>
+          <div class="fg-cast" id="fg-cast"></div>
+        </div>
+      </div>
+      <div class="fg-phase" id="fg-phase"></div>
+      <div class="pb-toast" id="fg-toast"></div>
+    </div>
+
+    <div class="pb-overlay" id="fg-overlay">
+      <div class="pb-panel">
+        <h2 id="fg-title">Pekkas Fiske</h2>
+        <p id="fg-text">Styr draget genom att dra med fingret. Väj för fisken på väg ner — kroka djupt, fånga allt på väg upp och tryck på fisken i luften!</p>
+        <div class="pb-scoreline" id="fg-scoreline" hidden></div>
+        <button class="pb-btn" id="fg-start">Kasta i!</button>
+      </div>
+    </div>
+
+    <button class="pb-mute" id="fg-mute" aria-label="Ljud på/av">
+      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M11 5 6 9H2v6h4l5 4V5Z"/><path class="pb-wave" d="M15.5 8.5a5 5 0 0 1 0 7"/>
+      </svg>
+    </button>
+  `;
+  return {
+    score: root.querySelector('#fg-score'),
+    hi: root.querySelector('#fg-hi'),
+    depth: root.querySelector('#fg-depth'),
+    cast: root.querySelector('#fg-cast'),
+    phase: root.querySelector('#fg-phase'),
+    toast: root.querySelector('#fg-toast'),
+    overlay: root.querySelector('#fg-overlay'),
+    title: root.querySelector('#fg-title'),
+    text: root.querySelector('#fg-text'),
+    scoreline: root.querySelector('#fg-scoreline'),
+    start: root.querySelector('#fg-start'),
+    mute: root.querySelector('#fg-mute')
+  };
+}
+
+/* ------------------------------------------------------------------ world */
+
+function buildFishMesh(sp) {
+  const g = new THREE.Group();
+  const bodyMat = new THREE.MeshLambertMaterial({ color: sp.color, flatShading: true });
+  const bellyMat = new THREE.MeshLambertMaterial({ color: sp.belly, flatShading: true });
+
+  const body = new THREE.Mesh(new THREE.SphereGeometry(0.5, 7, 5), bodyMat);
+  body.scale.set(1.7, 0.62, 0.5);
+  g.add(body);
+
+  const belly = new THREE.Mesh(new THREE.SphereGeometry(0.42, 7, 5), bellyMat);
+  belly.scale.set(1.5, 0.5, 0.42);
+  belly.position.y = -0.1;
+  g.add(belly);
+
+  const tail = new THREE.Mesh(new THREE.ConeGeometry(0.34, 0.62, 4), bodyMat);
+  tail.rotation.z = Math.PI / 2;
+  tail.position.x = -1.0;
+  tail.scale.z = 0.4;
+  g.add(tail);
+
+  const fin = new THREE.Mesh(new THREE.ConeGeometry(0.18, 0.4, 4), bodyMat);
+  fin.position.set(0.1, 0.4, 0);
+  fin.scale.z = 0.4;
+  g.add(fin);
+
+  const eyeGeo = new THREE.SphereGeometry(0.07, 6, 4);
+  const eyeMat = new THREE.MeshBasicMaterial({ color: 0x10152a });
+  [0.26, -0.26].forEach((z) => {
+    const eye = new THREE.Mesh(eyeGeo, eyeMat);
+    eye.position.set(0.62, 0.08, z * 0.5);
+    g.add(eye);
+  });
+
+  if (sp.rare) {
+    const crown = new THREE.Mesh(
+      new THREE.ConeGeometry(0.22, 0.34, 5),
+      new THREE.MeshLambertMaterial({ color: 0xffe08a, emissive: 0xf2c14e, emissiveIntensity: 0.7 })
+    );
+    crown.position.set(0.45, 0.55, 0);
+    g.add(crown);
+  }
+
+  g.scale.setScalar(sp.size);
+  g.userData.tail = tail;
+  return g;
+}
+
+function buildBoat() {
+  const g = new THREE.Group();
+  const hullMat = new THREE.MeshLambertMaterial({ color: 0x8a5a2b, flatShading: true });
+  const hull = new THREE.Mesh(new THREE.CylinderGeometry(1.5, 0.9, 4.4, 6, 1), hullMat);
+  hull.rotation.z = Math.PI / 2;
+  hull.scale.y = 0.55;
+  hull.scale.z = 0.62;
+  g.add(hull);
+
+  const rim = new THREE.Mesh(new THREE.TorusGeometry(1.9, 0.12, 6, 12), hullMat);
+  rim.rotation.x = Math.PI / 2;
+  rim.scale.set(1.2, 0.62, 1);
+  rim.position.y = 0.72;
+  g.add(rim);
+
+  // Fisherman: cap, head, body
+  const guy = new THREE.Group();
+  const body = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.32, 0.45, 0.9, 6),
+    new THREE.MeshLambertMaterial({ color: 0xf2c14e, flatShading: true })
+  );
+  body.position.y = 1.15;
+  guy.add(body);
+  const head = new THREE.Mesh(
+    new THREE.SphereGeometry(0.26, 7, 5),
+    new THREE.MeshLambertMaterial({ color: 0xe8b88a, flatShading: true })
+  );
+  head.position.y = 1.85;
+  guy.add(head);
+  const cap = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.28, 0.3, 0.16, 7),
+    new THREE.MeshLambertMaterial({ color: 0xb23a48, flatShading: true })
+  );
+  cap.position.y = 2.02;
+  guy.add(cap);
+  // Fishing rod
+  const rod = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.03, 0.05, 2.6, 5),
+    new THREE.MeshLambertMaterial({ color: 0x3a2b1a })
+  );
+  rod.position.set(1.1, 1.9, 0);
+  rod.rotation.z = -0.7;
+  guy.add(rod);
+  guy.position.x = -0.3;
+  g.add(guy);
+
+  return g;
+}
+
+/* ------------------------------------------------------------------- game */
+
+export async function createFishing(container) {
+  const canvasHost = document.createElement('div');
+  canvasHost.className = 'pb-canvas';
+  container.appendChild(canvasHost);
+
+  const hudHost = document.createElement('div');
+  hudHost.className = 'pb-ui fg-ui';
+  container.appendChild(hudHost);
+  const hud = buildHud(hudHost);
+
+  const sfx = new Sfx();
+
+  /* ---- Renderer: no post-processing — depth fog and flat shading carry
+     the look, and phones keep their frame rate ---- */
+  const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+  canvasHost.appendChild(renderer.domElement);
+
+  const scene = new THREE.Scene();
+  const SKY = new THREE.Color(0xffd9a0); // midnight sun
+  const SURF = new THREE.Color(0x1d6b74);
+  const DEEP = new THREE.Color(0x041020);
+  scene.background = SKY.clone();
+  scene.fog = new THREE.FogExp2(0x1d6b74, 0.028);
+
+  const camera = new THREE.PerspectiveCamera(55, 1, 0.1, 120);
+  camera.position.set(0, 4, 16);
+
+  /* ---- Lights ---- */
+  const hemi = new THREE.HemisphereLight(0xfff2d0, 0x0a2030, 1.0);
+  scene.add(hemi);
+  const sun = new THREE.DirectionalLight(0xffe0b0, 1.4);
+  sun.position.set(-14, 20, 8);
+  scene.add(sun);
+
+  /* ---- Sky: sun disc + shoreline silhouette ---- */
+  const skyGroup = new THREE.Group();
+  const sunDisc = new THREE.Mesh(
+    new THREE.CircleGeometry(3.2, 24),
+    new THREE.MeshBasicMaterial({ color: 0xffedc0, fog: false })
+  );
+  sunDisc.position.set(-10, 9.5, -30);
+  skyGroup.add(sunDisc);
+  const shoreMat = new THREE.MeshBasicMaterial({ color: 0x27333e, fog: false });
+  for (let i = 0; i < 26; i++) {
+    const h = 1.6 + Math.random() * 2.6;
+    const tree = new THREE.Mesh(new THREE.ConeGeometry(0.8, h, 5), shoreMat);
+    tree.position.set(-32 + i * 2.6 + Math.random(), 1.4 + h / 2, -28 - Math.random() * 4);
+    skyGroup.add(tree);
+  }
+  scene.add(skyGroup);
+
+  /* ---- Water surface: CPU-displaced low-poly sheet, visible from below ---- */
+  const surfGeo = new THREE.PlaneGeometry(90, 44, 36, 14);
+  surfGeo.rotateX(-Math.PI / 2);
+  const surfMat = new THREE.MeshLambertMaterial({
+    color: 0x2a8b96,
+    flatShading: true,
+    transparent: true,
+    opacity: 0.92,
+    side: THREE.DoubleSide
+  });
+  const surface = new THREE.Mesh(surfGeo, surfMat);
+  surface.position.y = 0;
+  scene.add(surface);
+  const surfPos = surfGeo.attributes.position;
+  const surfBase = surfPos.array.slice();
+
+  /* ---- Boat ---- */
+  const boat = buildBoat();
+  boat.position.set(0.5, 0.35, 0);
+  scene.add(boat);
+
+  /* ---- Light shafts near the surface ---- */
+  const shafts = [];
+  const shaftMat = new THREE.MeshBasicMaterial({
+    color: 0xbfe8d8,
+    transparent: true,
+    opacity: 0.1,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide
+  });
+  for (let i = 0; i < 6; i++) {
+    const shaft = new THREE.Mesh(new THREE.PlaneGeometry(1.4 + Math.random(), 16), shaftMat);
+    shaft.position.set(-10 + i * 4 + Math.random() * 2, -8, -3 - Math.random() * 3);
+    shaft.rotation.z = -0.22 + Math.random() * 0.1;
+    scene.add(shaft);
+    shafts.push(shaft);
+  }
+
+  /* ---- Seabed ---- */
+  const bedGroup = new THREE.Group();
+  bedGroup.position.y = -BOTTOM - 1.2;
+  const bed = new THREE.Mesh(
+    new THREE.PlaneGeometry(80, 30, 24, 8),
+    new THREE.MeshLambertMaterial({ color: 0x2b3140, flatShading: true })
+  );
+  bed.rotation.x = -Math.PI / 2;
+  const bp = bed.geometry.attributes.position;
+  for (let i = 0; i < bp.count; i++) bp.setZ(i, Math.random() * 1.4);
+  bed.geometry.computeVertexNormals();
+  bedGroup.add(bed);
+  const stoneMat = new THREE.MeshLambertMaterial({ color: 0x3d4558, flatShading: true });
+  for (let i = 0; i < 10; i++) {
+    const stone = new THREE.Mesh(new THREE.DodecahedronGeometry(0.5 + Math.random() * 0.9, 0), stoneMat);
+    stone.position.set(-18 + Math.random() * 36, 0.4, -4 + Math.random() * 6);
+    bedGroup.add(stone);
+  }
+  const weedMat = new THREE.MeshLambertMaterial({ color: 0x1f5c48, flatShading: true });
+  const weeds = [];
+  for (let i = 0; i < 14; i++) {
+    const weed = new THREE.Mesh(new THREE.ConeGeometry(0.16, 2.2 + Math.random() * 1.8, 4), weedMat);
+    weed.position.set(-16 + Math.random() * 32, 1.2, -3 + Math.random() * 5);
+    bedGroup.add(weed);
+    weeds.push(weed);
+  }
+  scene.add(bedGroup);
+
+  /* ---- Bubbles / drifting particles ---- */
+  const bubbleCount = 90;
+  const bubbleGeo = new THREE.BufferGeometry();
+  const bubblePos = new Float32Array(bubbleCount * 3);
+  for (let i = 0; i < bubbleCount; i++) {
+    bubblePos[i * 3] = -14 + Math.random() * 28;
+    bubblePos[i * 3 + 1] = -Math.random() * BOTTOM;
+    bubblePos[i * 3 + 2] = -4 + Math.random() * 6;
+  }
+  bubbleGeo.setAttribute('position', new THREE.BufferAttribute(bubblePos, 3));
+  const bubbles = new THREE.Points(
+    bubbleGeo,
+    new THREE.PointsMaterial({ color: 0x9fd8d0, size: 0.12, transparent: true, opacity: 0.5 })
+  );
+  scene.add(bubbles);
+
+  /* ---- Lure + line ---- */
+  const lure = new THREE.Group();
+  const sinker = new THREE.Mesh(
+    new THREE.SphereGeometry(0.28, 8, 6),
+    new THREE.MeshLambertMaterial({ color: 0xd23b4e, flatShading: true })
+  );
+  lure.add(sinker);
+  const hookMesh = new THREE.Mesh(
+    new THREE.TorusGeometry(0.16, 0.045, 6, 10, Math.PI * 1.4),
+    new THREE.MeshLambertMaterial({ color: 0xdfe6ff })
+  );
+  hookMesh.position.y = -0.34;
+  hookMesh.rotation.z = Math.PI * 0.8;
+  lure.add(hookMesh);
+  const glow = new THREE.PointLight(0xffd9a0, 0.7, 7, 2);
+  lure.add(glow);
+  scene.add(lure);
+
+  const lineGeo = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(),
+    new THREE.Vector3()
+  ]);
+  const line = new THREE.Line(lineGeo, new THREE.LineBasicMaterial({ color: 0xdde6f2, transparent: true, opacity: 0.6 }));
+  scene.add(line);
+
+  /* ---- Fish pool ---- */
+  const fishes = [];
+  function spawnFishSet() {
+    fishes.forEach((f) => scene.remove(f.mesh));
+    fishes.length = 0;
+    SPECIES.forEach((sp) => {
+      const count = sp.rare ? 1 : 9;
+      for (let i = 0; i < count; i++) {
+        if (sp.rare && Math.random() < 0.35) continue; // she is not always home
+        const mesh = buildFishMesh(sp);
+        const depth = sp.min + Math.random() * (sp.max - sp.min);
+        const dir = Math.random() < 0.5 ? 1 : -1;
+        mesh.position.set(-14 + Math.random() * 28, -depth, -1.5 + Math.random() * 3);
+        mesh.scale.x *= dir > 0 ? 1 : -1;
+        scene.add(mesh);
+        fishes.push({
+          sp,
+          mesh,
+          dir,
+          speed: sp.speed * (0.8 + Math.random() * 0.5),
+          phase: Math.random() * Math.PI * 2,
+          caught: false,
+          air: null
+        });
+      }
+    });
+  }
+
+  /* ------------------------------------------------------------- state */
+
+  const state = {
+    phase: 'idle', // idle | drop | reel | toss | between | over
+    score: 0,
+    castNo: 1,
+    depth: 0,
+    lureX: 0,
+    targetX: 0,
+    dropSpeed: 6,
+    caught: [],
+    combo: 0,
+    tossLeft: 0,
+    best: 0,
+    lastToast: 0
+  };
+
+  let high = 0;
+  try {
+    high = parseInt(localStorage.getItem(HIGHSCORE_KEY) || '0', 10) || 0;
+  } catch (e) {
+    high = 0;
+  }
+  hud.hi.textContent = high.toLocaleString('sv-SE');
+
+  const fmt = (n) => n.toLocaleString('sv-SE');
+
+  function toast(msg, big = false) {
+    hud.toast.textContent = msg;
+    hud.toast.className = `pb-toast show${big ? ' big' : ''}`;
+    clearTimeout(state.lastToast);
+    state.lastToast = setTimeout(() => {
+      hud.toast.className = 'pb-toast';
+    }, big ? 1700 : 1000);
+  }
+
+  function addScore(n) {
+    state.score += n;
+    hud.score.textContent = fmt(state.score);
+  }
+
+  function setPhaseLabel(txt) {
+    hud.phase.textContent = txt;
+    hud.phase.classList.toggle('show', !!txt);
+  }
+
+  function renderCast() {
+    hud.cast.textContent = `KAST ${Math.min(state.castNo, CASTS_PER_GAME)}/${CASTS_PER_GAME}`;
+  }
+
+  /* ------------------------------------------------------- phase control */
+
+  function startCast() {
+    state.phase = 'drop';
+    state.depth = 0;
+    state.dropSpeed = 6;
+    state.lureX = 0;
+    state.targetX = 0;
+    state.caught = [];
+    state.combo = 0;
+    spawnFishSet();
+    sfx.splash();
+    setPhaseLabel('VÄJ FÖR FISKEN — djupare ner finns finare fångst');
+    setTimeout(() => setPhaseLabel(''), 2600);
+    renderCast();
+  }
+
+  function hookAt(fish) {
+    // Hooked (or bottomed): the reel turns and now every fish counts
+    state.phase = 'reel';
+    sfx.hook();
+    if (fish) catchOne(fish);
+    setPhaseLabel('VEVA! Fånga allt på vägen upp!');
+    setTimeout(() => setPhaseLabel(''), 2200);
+    if (navigator.vibrate) navigator.vibrate(30);
+  }
+
+  function catchOne(f) {
+    f.caught = true;
+    state.combo++;
+    state.caught.push(f);
+    addScore(f.sp.pts);
+    sfx.catchFish(state.combo);
+    if (f.sp.rare) {
+      sfx.legend();
+      toast('PEKKAGÄDDAN ÄR KROKAD!! +500', true);
+    } else {
+      toast(`${f.sp.name} +${f.sp.pts}`);
+    }
+    if (navigator.vibrate) navigator.vibrate(15);
+  }
+
+  function startToss() {
+    state.phase = 'toss';
+    sfx.toss();
+    setPhaseLabel('TRYCK PÅ FISKEN — i tunnan för dubbelt!');
+    state.tossLeft = state.caught.length;
+    const n = state.caught.length;
+    state.caught.forEach((f, i) => {
+      const spread = n > 1 ? (i / (n - 1)) * 2 - 1 : 0;
+      f.air = {
+        x: boat.position.x + spread * 1.5,
+        y: 1.2,
+        vx: spread * 4.2 + (Math.random() - 0.5) * 1.5,
+        vy: 13 + Math.random() * 4,
+        done: false
+      };
+      f.mesh.visible = true;
+      f.mesh.scale.setScalar(f.sp.size * 0.85);
+    });
+    if (n === 0) setTimeout(endCast, 900);
+  }
+
+  function endCast() {
+    setPhaseLabel('');
+    if (state.castNo >= CASTS_PER_GAME) {
+      gameOver();
+      return;
+    }
+    state.castNo++;
+    state.phase = 'between';
+    renderCast();
+    toast(`Kast ${state.castNo} av ${CASTS_PER_GAME}`, true);
+    setTimeout(() => {
+      if (state.phase === 'between') startCast();
+    }, 1400);
+  }
+
+  function gameOver() {
+    state.phase = 'over';
+    const isHigh = state.score > high;
+    if (isHigh) {
+      high = state.score;
+      try {
+        localStorage.setItem(HIGHSCORE_KEY, String(high));
+      } catch (e) {
+        /* private mode */
+      }
+      hud.hi.textContent = fmt(high);
+    }
+    sfx.fanfare();
+    hud.title.textContent = isHigh ? 'Nytt rekord!' : 'Fisket är slut';
+    hud.text.textContent = isHigh
+      ? 'Största fångsten hittills på den här enheten. Petri heder!'
+      : 'Tre kast, sen är det kaffe och rökt sik. En tur till?';
+    hud.scoreline.hidden = false;
+    hud.scoreline.innerHTML = `<span>${fmt(state.score)}</span><small>poäng · rekord ${fmt(high)}</small>`;
+    hud.start.textContent = 'Fiska igen';
+    hud.overlay.classList.add('show');
+  }
+
+  function startGame() {
+    sfx.resume();
+    state.score = 0;
+    state.castNo = 1;
+    hud.score.textContent = '0';
+    hud.scoreline.hidden = true;
+    hud.overlay.classList.remove('show');
+    startCast();
+  }
+
+  /* -------------------------------------------------------------- input */
+
+  let dragging = false;
+
+  function pointerToX(e) {
+    const rect = canvasHost.getBoundingClientRect();
+    return ((e.clientX - rect.left) / rect.width) * 2 - 1;
+  }
+
+  function onPointerDown(e) {
+    sfx.resume();
+    if (e.target.closest('.pb-overlay, .pb-mute')) return;
+
+    if (state.phase === 'toss') {
+      tryTapFish(e);
+      return;
+    }
+    dragging = true;
+    state.targetX = pointerToX(e) * 9;
+  }
+
+  function onPointerMove(e) {
+    if (!dragging) return;
+    state.targetX = pointerToX(e) * 9;
+  }
+
+  function onPointerUp() {
+    dragging = false;
+  }
+
+  function onKeyDown(e) {
+    const k = e.key.toLowerCase();
+    if (k === 'arrowleft' || k === 'a') state.targetX = Math.max(-9, state.targetX - 2.4);
+    else if (k === 'arrowright' || k === 'd') state.targetX = Math.min(9, state.targetX + 2.4);
+    else if (k === ' ' && (state.phase === 'idle' || state.phase === 'over')) {
+      e.preventDefault();
+      startGame();
+    }
+  }
+
+  /* Tap detection in the toss phase: closest airborne fish in screen space */
+  const ndc = new THREE.Vector3();
+
+  function tryTapFish(e) {
+    const rect = canvasHost.getBoundingClientRect();
+    const tx = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    const ty = -(((e.clientY - rect.top) / rect.height) * 2 - 1);
+    let bestF = null;
+    let bestD = 0.16; // generous thumb radius in NDC
+    state.caught.forEach((f) => {
+      if (!f.air || f.air.done) return;
+      ndc.copy(f.mesh.position).project(camera);
+      const d = Math.hypot(ndc.x - tx, ndc.y - ty);
+      if (d < bestD) {
+        bestD = d;
+        bestF = f;
+      }
+    });
+    if (bestF) {
+      bestF.air.done = 'hit';
+      state.tossLeft--;
+      addScore(bestF.sp.pts); // doubles the fish
+      sfx.tap(state.caught.length - state.tossLeft);
+      toast(`${bestF.sp.name} i tunnan! +${bestF.sp.pts}`);
+      // fly to the barrel
+      bestF.air.vx = (boat.position.x + 2.6 - bestF.mesh.position.x) * 3;
+      bestF.air.vy = 7;
+      if (navigator.vibrate) navigator.vibrate(12);
+      if (state.tossLeft <= 0) setTimeout(endCast, 700);
+    }
+  }
+
+  canvasHost.addEventListener('pointerdown', onPointerDown);
+  canvasHost.addEventListener('pointermove', onPointerMove);
+  window.addEventListener('pointerup', onPointerUp);
+  window.addEventListener('keydown', onKeyDown);
+  hud.start.addEventListener('click', startGame);
+  hud.mute.addEventListener('click', () => {
+    sfx.muted = !sfx.muted;
+    hud.mute.classList.toggle('off', sfx.muted);
+  });
+
+  /* -------------------------------------------------------------- sizing */
+
+  function resize() {
+    const rect = canvasHost.getBoundingClientRect();
+    const w = Math.max(1, Math.floor(rect.width));
+    const h = Math.max(1, Math.floor(rect.height));
+    renderer.setSize(w, h, false);
+    camera.aspect = w / h;
+    camera.fov = camera.aspect < 0.7 ? 62 : 55;
+    camera.updateProjectionMatrix();
+  }
+
+  const ro = new ResizeObserver(resize);
+  ro.observe(canvasHost);
+  resize();
+
+  /* ---------------------------------------------------------------- loop */
+
+  let raf = 0;
+  let last = performance.now();
+  let running = true;
+  const camTarget = new THREE.Vector3(0, 2, 0);
+  const tmpColor = new THREE.Color();
+
+  function tick(now) {
+    raf = requestAnimationFrame(tick);
+    const dt = Math.min(0.05, (now - last) / 1000);
+    last = now;
+    if (!running) return;
+    const t = now / 1000;
+
+    /* Surface waves */
+    for (let i = 0; i < surfPos.count; i++) {
+      const x = surfBase[i * 3];
+      const z = surfBase[i * 3 + 2];
+      surfPos.setY(i, Math.sin(x * 0.5 + t * 1.3) * 0.22 + Math.cos(z * 0.7 + t * 0.9) * 0.18);
+    }
+    surfPos.needsUpdate = true;
+    surface.geometry.computeVertexNormals();
+
+    boat.position.y = 0.35 + Math.sin(t * 1.1) * 0.12;
+    boat.rotation.z = Math.sin(t * 0.9) * 0.03;
+
+    weeds.forEach((w, i) => {
+      w.rotation.x = Math.sin(t * 0.8 + i) * 0.12;
+    });
+    shafts.forEach((s, i) => {
+      s.material.opacity = 0.06 + Math.sin(t * 0.5 + i * 1.7) * 0.045;
+    });
+
+    /* Fish swim */
+    fishes.forEach((f) => {
+      if (f.caught) return;
+      f.mesh.position.x += f.dir * f.speed * dt;
+      f.mesh.position.y += Math.sin(t * 2 + f.phase) * 0.15 * dt;
+      f.userDataWiggle = Math.sin(t * 8 + f.phase) * 0.3;
+      f.mesh.userData.tail.rotation.y = f.userDataWiggle;
+      if (f.dir > 0 && f.mesh.position.x > 16) {
+        f.mesh.position.x = -16;
+      } else if (f.dir < 0 && f.mesh.position.x < -16) {
+        f.mesh.position.x = 16;
+      }
+    });
+
+    /* Phases */
+    if (state.phase === 'drop') {
+      state.dropSpeed = Math.min(15, state.dropSpeed + dt * 1.6);
+      state.depth += state.dropSpeed * dt;
+      state.lureX += (state.targetX - state.lureX) * Math.min(1, dt * 6);
+      sfx.reel();
+
+      if (state.depth >= BOTTOM) {
+        state.depth = BOTTOM;
+        toast('Botten! Nu vevar vi.', true);
+        hookAt(null);
+      } else {
+        // Touching a fish on the way down hooks it
+        for (const f of fishes) {
+          if (f.caught) continue;
+          const dx = f.mesh.position.x - state.lureX;
+          const dy = f.mesh.position.y + state.depth;
+          if (Math.abs(dx) < 0.9 * f.sp.size + 0.3 && Math.abs(dy) < 0.7 * f.sp.size + 0.3) {
+            hookAt(f);
+            break;
+          }
+        }
+      }
+    } else if (state.phase === 'reel') {
+      state.depth -= 16 * dt;
+      state.lureX += (state.targetX - state.lureX) * Math.min(1, dt * 7);
+
+      for (const f of fishes) {
+        if (f.caught) continue;
+        const dx = f.mesh.position.x - state.lureX;
+        const dy = f.mesh.position.y + state.depth;
+        if (Math.abs(dx) < 1.1 * f.sp.size + 0.35 && Math.abs(dy) < 0.9 * f.sp.size + 0.35) {
+          catchOne(f);
+        }
+      }
+
+      if (state.depth <= 0) {
+        state.depth = 0;
+        startToss();
+      }
+    } else if (state.phase === 'toss') {
+      state.caught.forEach((f) => {
+        if (!f.air) return;
+        if (f.air.done === 'hit' && f.mesh.position.y < 1.0) {
+          f.mesh.visible = false;
+          f.air = { done: true };
+          return;
+        }
+        if (f.air.done === true) return;
+        f.air.vy -= 20 * dt;
+        f.air.x += f.air.vx * dt;
+        f.air.y += f.air.vy * dt;
+        f.mesh.position.set(f.air.x, f.air.y, 1.5);
+        f.mesh.rotation.z += dt * 7;
+        if (f.air.y < -0.4 && f.air.done !== 'hit') {
+          // splashed back — lost the bonus
+          f.air.done = true;
+          f.mesh.visible = false;
+          state.tossLeft--;
+          sfx.miss();
+          if (state.tossLeft <= 0) setTimeout(endCast, 600);
+        }
+      });
+    }
+
+    /* Lure follows */
+    const lureY = -state.depth;
+    lure.position.set(state.lureX, lureY, 0);
+    lure.rotation.z = (state.targetX - state.lureX) * -0.08;
+    lure.visible = state.phase === 'drop' || state.phase === 'reel';
+    line.visible = lure.visible;
+    if (lure.visible) {
+      const pts = line.geometry.attributes.position.array;
+      pts[0] = boat.position.x + 1.6;
+      pts[1] = boat.position.y + 1.4;
+      pts[2] = 0;
+      pts[3] = state.lureX;
+      pts[4] = lureY + 0.3;
+      pts[5] = 0;
+      line.geometry.attributes.position.needsUpdate = true;
+    }
+
+    /* Caught fish trail behind the lure during the reel */
+    if (state.phase === 'reel' || state.phase === 'drop') {
+      state.caught.forEach((f, i) => {
+        f.mesh.visible = true;
+        f.mesh.position.x += (state.lureX - f.mesh.position.x) * Math.min(1, dt * 8);
+        f.mesh.position.y = lureY - 0.9 - i * 0.75;
+        f.mesh.position.z = 0.2;
+        f.mesh.rotation.z = Math.PI / 2 + Math.sin(t * 6 + i) * 0.2;
+      });
+    }
+
+    /* Camera + atmosphere by depth */
+    const focus = state.phase === 'toss' ? 4 : Math.max(2 - state.depth, -state.depth + 3.5);
+    camTarget.set(state.lureX * 0.45, state.phase === 'idle' || state.phase === 'over' ? 2 : focus, 0);
+    camera.position.x += (camTarget.x - camera.position.x) * Math.min(1, dt * 3);
+    camera.position.y += (camTarget.y + 1.5 - camera.position.y) * Math.min(1, dt * 4);
+    camera.lookAt(camTarget.x, camTarget.y, 0);
+
+    const k = Math.min(1, state.depth / 45);
+    if (state.depth > 1) {
+      tmpColor.copy(SURF).lerp(DEEP, k);
+    } else {
+      tmpColor.copy(SKY);
+    }
+    scene.background.lerp(tmpColor, Math.min(1, dt * 3));
+    scene.fog.color.copy(scene.background);
+    scene.fog.density = 0.016 + k * 0.03;
+    hemi.intensity = 1.0 - k * 0.62;
+    sun.intensity = 1.4 - k * 1.0;
+
+    hud.depth.textContent = `${Math.round(state.depth)} m`;
+
+    renderer.render(scene, camera);
+  }
+
+  raf = requestAnimationFrame(tick);
+
+  const onVisibility = () => {
+    running = !document.hidden;
+    last = performance.now();
+  };
+  document.addEventListener('visibilitychange', onVisibility);
+
+  renderCast();
+  hud.overlay.classList.add('show');
+  spawnFishSet();
+
+  /* Deterministic hooks for automated tests */
+  window.__ppFiske = {
+    state,
+    startGame,
+    forceHook() {
+      if (state.phase === 'drop') hookAt(null);
+    },
+    forceCatch(n = 3) {
+      fishes
+        .filter((f) => !f.caught)
+        .slice(0, n)
+        .forEach((f) => catchOne(f));
+    },
+    toSurface() {
+      state.depth = 0.01;
+    },
+    toBottom() {
+      state.depth = BOTTOM - 0.5;
+    },
+    tapAll() {
+      state.caught.forEach((f) => {
+        if (f.air && !f.air.done) {
+          f.air.done = 'hit';
+          state.tossLeft--;
+          addScore(f.sp.pts);
+        }
+      });
+      if (state.tossLeft <= 0) setTimeout(endCast, 100);
+    },
+    fishes
+  };
+
+  /* ---- Teardown ---- */
+  function destroy() {
+    cancelAnimationFrame(raf);
+    running = false;
+    ro.disconnect();
+    document.removeEventListener('visibilitychange', onVisibility);
+    canvasHost.removeEventListener('pointerdown', onPointerDown);
+    canvasHost.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', onPointerUp);
+    window.removeEventListener('keydown', onKeyDown);
+    clearTimeout(state.lastToast);
+    delete window.__ppFiske;
+
+    scene.traverse((o) => {
+      if (o.geometry) o.geometry.dispose();
+      if (o.material) {
+        const mats = Array.isArray(o.material) ? o.material : [o.material];
+        mats.forEach((m) => m.dispose());
+      }
+    });
+    renderer.dispose();
+    renderer.forceContextLoss?.();
+    if (sfx.ctx) sfx.ctx.close();
+    container.innerHTML = '';
+  }
+
+  return { destroy };
+}
+
+export default createFishing;

--- a/src/games/fishing/species.js
+++ b/src/games/fishing/species.js
@@ -1,0 +1,553 @@
+/**
+ * Pekkas Fiske — procedural fish.
+ *
+ * Every species is generated from a spine profile plus a handful of fin
+ * blades, merged down to three meshes (one per body joint) so a whole
+ * shoal costs almost nothing to draw. Markings — countershading, the
+ * perch's bars, the pike's pale beans, the salmon's spots — are painted
+ * into the vertex colours while the rings are generated, so there is not
+ * a single texture in the water.
+ *
+ * The three joints form a chain, so the body actually undulates with a
+ * travelling wave instead of just flapping a cone at the back.
+ */
+
+import * as THREE from 'three';
+
+/* ------------------------------------------------------------- geometry kit */
+
+/** Merge non-indexed pieces into one geometry with position/normal/colour. */
+function mergeParts(parts) {
+  let total = 0;
+  parts.forEach((p) => {
+    total += p.geometry.attributes.position.count;
+  });
+  const pos = new Float32Array(total * 3);
+  const nor = new Float32Array(total * 3);
+  const col = new Float32Array(total * 3);
+  let o = 0;
+  parts.forEach((part) => {
+    const g = part.geometry;
+    const P = g.attributes.position;
+    const N = g.attributes.normal;
+    const C = g.attributes.color;
+    for (let i = 0; i < P.count; i++) {
+      pos[(o + i) * 3] = P.getX(i);
+      pos[(o + i) * 3 + 1] = P.getY(i);
+      pos[(o + i) * 3 + 2] = P.getZ(i);
+      nor[(o + i) * 3] = N ? N.getX(i) : 0;
+      nor[(o + i) * 3 + 1] = N ? N.getY(i) : 1;
+      nor[(o + i) * 3 + 2] = N ? N.getZ(i) : 0;
+      col[(o + i) * 3] = C ? C.getX(i) : part.color.r;
+      col[(o + i) * 3 + 1] = C ? C.getY(i) : part.color.g;
+      col[(o + i) * 3 + 2] = C ? C.getZ(i) : part.color.b;
+    }
+    o += P.count;
+    g.dispose();
+  });
+  const out = new THREE.BufferGeometry();
+  out.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  out.setAttribute('normal', new THREE.BufferAttribute(nor, 3));
+  out.setAttribute('color', new THREE.BufferAttribute(col, 3));
+  return out;
+}
+
+/**
+ * A flat blade from a 2D outline, fanned from the first point and given a
+ * little thickness. Every fin in the game is one of these.
+ */
+function blade(pts, thickness, color, matrix) {
+  const v = [];
+  const half = thickness / 2;
+  const push = (x, y, z) => v.push(x, y, z);
+  for (let i = 1; i < pts.length - 1; i++) {
+    const a = pts[0], b = pts[i], c = pts[i + 1];
+    push(a[0], a[1], half); push(b[0], b[1], half); push(c[0], c[1], half);
+    push(a[0], a[1], -half); push(c[0], c[1], -half); push(b[0], b[1], -half);
+  }
+  for (let i = 0; i < pts.length; i++) {
+    const a = pts[i], b = pts[(i + 1) % pts.length];
+    push(a[0], a[1], half); push(a[0], a[1], -half); push(b[0], b[1], half);
+    push(b[0], b[1], half); push(a[0], a[1], -half); push(b[0], b[1], -half);
+  }
+  const g = new THREE.BufferGeometry();
+  g.setAttribute('position', new THREE.BufferAttribute(new Float32Array(v), 3));
+  if (matrix) g.applyMatrix4(matrix);
+  g.computeVertexNormals();
+  const n = v.length / 3;
+  const c = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    c[i * 3] = color.r;
+    c[i * 3 + 1] = color.g;
+    c[i * 3 + 2] = color.b;
+  }
+  g.setAttribute('color', new THREE.BufferAttribute(c, 3));
+  return g;
+}
+
+const M = (x, y, z, rz = 0, sx = 1, sy = 1, sz = 1) =>
+  new THREE.Matrix4()
+    .makeRotationZ(rz)
+    .premultiply(new THREE.Matrix4().makeTranslation(x, y, z))
+    .multiply(new THREE.Matrix4().makeScale(sx, sy, sz));
+
+/**
+ * Build a body section between two points of the spine profile.
+ * `paint(u, y, r, x)` returns the vertex colour, which is where the
+ * countershading and the species markings come from.
+ */
+function bodySection(profile, uA, uB, rings, radial, paint) {
+  const pos = [];
+  const col = [];
+  const at = (u) => {
+    const r = profile.radius(u);
+    return { x: profile.x(u), ry: r * profile.height, rz: r * profile.width };
+  };
+  const ringPt = (u, k) => {
+    const a = (k / radial) * Math.PI * 2;
+    const s = at(u);
+    return [s.x, Math.cos(a) * s.ry, Math.sin(a) * s.rz];
+  };
+  const put = (u, p) => {
+    pos.push(p[0], p[1], p[2]);
+    const c = paint(u, p[1], at(u).ry, p[0]);
+    col.push(c.r, c.g, c.b);
+  };
+
+  for (let i = 0; i < rings; i++) {
+    const u0 = uA + ((uB - uA) * i) / rings;
+    const u1 = uA + ((uB - uA) * (i + 1)) / rings;
+    for (let k = 0; k < radial; k++) {
+      const a0 = ringPt(u0, k), a1 = ringPt(u0, k + 1);
+      const b0 = ringPt(u1, k), b1 = ringPt(u1, k + 1);
+      put(u0, a0); put(u1, b0); put(u0, a1);
+      put(u0, a1); put(u1, b0); put(u1, b1);
+    }
+  }
+  // Caps so the nose and the peduncle are closed solids
+  [[uA, true], [uB, false]].forEach(([u, front]) => {
+    const s = at(u);
+    if (s.ry < 0.012) return;
+    for (let k = 0; k < radial; k++) {
+      const a = ringPt(u, k), b = ringPt(u, k + 1);
+      const c = [s.x, 0, 0];
+      if (front) {
+        put(u, c); put(u, a); put(u, b);
+      } else {
+        put(u, c); put(u, b); put(u, a);
+      }
+    }
+  });
+
+  const g = new THREE.BufferGeometry();
+  g.setAttribute('position', new THREE.BufferAttribute(new Float32Array(pos), 3));
+  g.setAttribute('color', new THREE.BufferAttribute(new Float32Array(col), 3));
+  g.computeVertexNormals();
+  return g;
+}
+
+/* ------------------------------------------------------------------ species */
+
+const C = (h) => new THREE.Color(h);
+
+/** Smooth spine profile from control points, plus body proportions. */
+function makeProfile(points, opts) {
+  const radius = (u) => {
+    const t = Math.min(1, Math.max(0, u));
+    for (let i = 0; i < points.length - 1; i++) {
+      const a = points[i], b = points[i + 1];
+      if (t >= a[0] && t <= b[0]) {
+        const k = (t - a[0]) / (b[0] - a[0] || 1);
+        const s = k * k * (3 - 2 * k); // smoothstep keeps the body organic
+        return a[1] + (b[1] - a[1]) * s;
+      }
+    }
+    return points[points.length - 1][1];
+  };
+  return {
+    radius,
+    height: opts.height,
+    width: opts.width,
+    x: (u) => opts.nose - u * (opts.nose - opts.tail)
+  };
+}
+
+/** Countershading: dark back, pale belly, with an optional marking hook. */
+function shader(back, belly, mark) {
+  return (u, y, ry, x) => {
+    const k = Math.min(1, Math.max(0, y / (ry || 1) * 0.5 + 0.5));
+    const s = k * k * (3 - 2 * k);
+    const c = belly.clone().lerp(back, s);
+    return mark ? mark(c, u, y, ry, x) : c;
+  };
+}
+
+const bars = (dark) => (c, u, y, ry, x) => {
+  const phase = Math.sin(x * 7.5 + 0.6);
+  if (phase > 0.55 && y > -ry * 0.15) c.lerp(dark, 0.62 * (phase - 0.55) / 0.45);
+  return c;
+};
+
+const beans = (pale) => (c, u, y, ry, x) => {
+  const h = Math.sin(x * 11.3) * Math.cos(y * 9.1 + x * 3.7);
+  if (h > 0.62) c.lerp(pale, 0.7);
+  return c;
+};
+
+const specks = (dark) => (c, u, y, ry, x) => {
+  const h = Math.sin(x * 17.7 + 1.3) * Math.sin(y * 21.3);
+  if (h > 0.72 && y > 0) c.lerp(dark, 0.75);
+  return c;
+};
+
+const flank = (stripe) => (c, u, y, ry) => {
+  if (Math.abs(y) < ry * 0.28) c.lerp(stripe, 0.45);
+  return c;
+};
+
+/**
+ * The catalogue. `min`/`max` are the depths in metres where each species
+ * lives, which is what turns "go deeper" into "go for the good stuff".
+ */
+export const SPECIES = [
+  {
+    id: 'mort',
+    name: 'Mört',
+    pts: 100,
+    min: 1,
+    max: 15,
+    size: 0.42,
+    speed: 2.6,
+    profile: makeProfile([[0, 0.05], [0.18, 0.34], [0.42, 0.4], [0.75, 0.16], [1, 0.05]],
+      { height: 1.35, width: 0.62, nose: 1, tail: -0.72 }),
+    paint: shader(C(0x4d6f96), C(0xeef4fb)),
+    fin: C(0xd2452f),
+    tail: 'fork',
+    dorsal: { at: -0.02, h: 0.4, w: 0.34, back: 0.16 },
+    eye: 0.16
+  },
+  {
+    id: 'abborre',
+    name: 'Abborre',
+    pts: 250,
+    min: 4,
+    max: 28,
+    size: 0.54,
+    speed: 3.0,
+    profile: makeProfile([[0, 0.06], [0.16, 0.36], [0.38, 0.46], [0.72, 0.15], [1, 0.05]],
+      { height: 1.5, width: 0.58, nose: 1, tail: -0.74 }),
+    paint: shader(C(0x33591f), C(0xf0e6bd), bars(C(0x14290c))),
+    fin: C(0xe06010),
+    tail: 'fan',
+    dorsal: { at: 0.1, h: 0.46, w: 0.5, back: 0.1, spiny: true },
+    dorsal2: { at: -0.28, h: 0.26, w: 0.24, back: 0.12 },
+    eye: 0.17
+  },
+  {
+    id: 'sik',
+    name: 'Sik',
+    pts: 400,
+    min: 12,
+    max: 40,
+    size: 0.62,
+    speed: 3.4,
+    profile: makeProfile([[0, 0.04], [0.2, 0.28], [0.45, 0.32], [0.78, 0.12], [1, 0.04]],
+      { height: 1.25, width: 0.66, nose: 1.05, tail: -0.78 }),
+    paint: shader(C(0x5d7f96), C(0xf6fafd), flank(C(0xc9dced))),
+    fin: C(0x9fb6c6),
+    tail: 'fork',
+    dorsal: { at: 0.02, h: 0.32, w: 0.28, back: 0.14 },
+    adipose: -0.42,
+    eye: 0.15
+  },
+  {
+    id: 'gadda',
+    name: 'Gädda',
+    pts: 800,
+    min: 18,
+    max: 52,
+    size: 0.95,
+    speed: 3.9,
+    profile: makeProfile([[0, 0.05], [0.12, 0.2], [0.3, 0.29], [0.62, 0.26], [0.86, 0.1], [1, 0.05]],
+      { height: 1.1, width: 0.78, nose: 1.35, tail: -0.85 }),
+    paint: shader(C(0x2c4a22), C(0xdfd79a), beans(C(0xbcd07a))),
+    fin: C(0x6b7f3c),
+    tail: 'fork',
+    dorsal: { at: -0.52, h: 0.42, w: 0.34, back: 0.1 },
+    snout: true,
+    eye: 0.14
+  },
+  {
+    id: 'lax',
+    name: 'Lax',
+    pts: 1500,
+    min: 30,
+    max: 57,
+    size: 0.85,
+    speed: 4.6,
+    profile: makeProfile([[0, 0.05], [0.16, 0.3], [0.4, 0.38], [0.76, 0.13], [1, 0.045]],
+      { height: 1.3, width: 0.68, nose: 1.15, tail: -0.82 }),
+    paint: shader(C(0x3f5f8c), C(0xf7d8cb), specks(C(0x1a2436))),
+    fin: C(0x6f7f9c),
+    tail: 'fork',
+    dorsal: { at: 0.0, h: 0.36, w: 0.3, back: 0.13 },
+    adipose: -0.44,
+    eye: 0.16
+  },
+  {
+    id: 'pekka',
+    name: 'PEKKAGÄDDAN',
+    pts: 5000,
+    min: 48,
+    max: 59,
+    size: 1.6,
+    speed: 5.0,
+    rare: true,
+    profile: makeProfile([[0, 0.05], [0.12, 0.22], [0.3, 0.31], [0.62, 0.28], [0.86, 0.11], [1, 0.05]],
+      { height: 1.12, width: 0.8, nose: 1.35, tail: -0.85 }),
+    paint: shader(C(0xd39a1c), C(0xfff0bd), beans(C(0xfff6d8))),
+    fin: C(0xf2c14e),
+    tail: 'fork',
+    dorsal: { at: -0.52, h: 0.44, w: 0.36, back: 0.1 },
+    snout: true,
+    crown: true,
+    eye: 0.15
+  }
+];
+
+/** Snags: no points, but they end the drop. Risk on the way down. */
+export const JUNK = [
+  { id: 'stovel', name: 'Gammal stövel', size: 0.62, min: 4, max: 46 },
+  { id: 'burk', name: 'Rostig burk', size: 0.42, min: 6, max: 50 },
+  { id: 'dack', name: 'Cykeldäck', size: 0.85, min: 12, max: 55 }
+];
+
+/* ---------------------------------------------------------------- assembly */
+
+const EYE_DARK = C(0x0a0f1c);
+const EYE_WHITE = C(0xf2f6ff);
+
+function tailBlade(kind, fin) {
+  const parts = [];
+  if (kind === 'fork') {
+    parts.push(blade([[0, 0], [-0.5, 0.52], [-0.62, 0.3], [-0.16, 0.02]], 0.05, fin));
+    parts.push(blade([[0, 0], [-0.16, -0.02], [-0.62, -0.3], [-0.5, -0.52]], 0.05, fin));
+  } else {
+    parts.push(blade([[0, 0.04], [-0.34, 0.42], [-0.5, 0], [-0.34, -0.42], [0, -0.04]], 0.05, fin));
+  }
+  return parts;
+}
+
+function dorsalBlade(d, fin) {
+  if (!d) return [];
+  if (d.spiny) {
+    const out = [];
+    const n = 5;
+    for (let i = 0; i < n; i++) {
+      const x = d.at - (i / n) * d.w;
+      const h = d.h * (1 - Math.abs(i - 1.2) / (n * 1.6));
+      out.push(blade([[x, 0], [x - 0.09, h], [x - 0.15, 0]], 0.04, fin));
+    }
+    return out;
+  }
+  return [blade([[d.at, 0], [d.at - d.w * 0.35, d.h], [d.at - d.w, d.h * 0.25], [d.at - d.w, 0]], 0.045, fin)];
+}
+
+function buildSpecies(sp) {
+  const rad = 7;
+  const { paint } = sp;
+  const finC = sp.fin;
+
+  /* --- Segment A: nose to the first joint, plus head detail and fins --- */
+  const headParts = [{ geometry: bodySection(sp.profile, 0, 0.52, 6, rad, paint), color: finC }];
+
+  if (sp.snout) {
+    // A pike's duck-bill: a flattened wedge grafted onto the nose
+    const nx = sp.profile.x(0);
+    headParts.push({
+      geometry: blade([[nx + 0.3, 0.04], [nx + 0.3, -0.05], [nx - 0.18, -0.14], [nx - 0.18, 0.13]],
+        0.2, paint(0.05, 0, 0.2, nx)),
+      color: finC
+    });
+  }
+
+  dorsalBlade(sp.dorsal, finC).forEach((g) => {
+    if (sp.dorsal.at > -0.3) headParts.push({ geometry: g, color: finC });
+  });
+  dorsalBlade(sp.dorsal2, finC).forEach((g) => headParts.push({ geometry: g, color: finC }));
+
+  // Pectorals, one each side, swept back
+  [1, -1].forEach((s) => {
+    headParts.push({
+      geometry: blade([[0.25, 0], [0.02, -0.16], [0.06, -0.3], [0.3, -0.1]], 0.035, finC,
+        M(0, -0.06, s * sp.profile.radius(0.35) * sp.profile.width * 0.85, 0, 1, 1, 1)),
+      color: finC
+    });
+  });
+
+  // Eyes: dark pupil on a pale ring so they read at any depth
+  const ex = sp.profile.x(sp.snout ? 0.2 : 0.13);
+  const ez = sp.profile.radius(sp.snout ? 0.2 : 0.13) * sp.profile.width;
+  [1, -1].forEach((s) => {
+    const white = new THREE.SphereGeometry(sp.eye, 6, 4);
+    white.applyMatrix4(M(ex, sp.profile.radius(0.15) * sp.profile.height * 0.32, s * ez * 0.85));
+    headParts.push({ geometry: white.toNonIndexed(), color: EYE_WHITE });
+    const pupil = new THREE.SphereGeometry(sp.eye * 0.55, 6, 4);
+    pupil.applyMatrix4(M(ex + 0.02, sp.profile.radius(0.15) * sp.profile.height * 0.32, s * ez * 0.97));
+    headParts.push({ geometry: pupil.toNonIndexed(), color: EYE_DARK });
+  });
+
+  if (sp.crown) {
+    const crown = new THREE.CylinderGeometry(0.19, 0.15, 0.2, 5, 1, true);
+    crown.applyMatrix4(M(0.32, sp.profile.radius(0.32) * sp.profile.height + 0.08, 0));
+    headParts.push({ geometry: crown.toNonIndexed(), color: C(0xffe9a8) });
+    for (let i = 0; i < 5; i++) {
+      const spike = new THREE.ConeGeometry(0.055, 0.16, 4);
+      const a = (i / 5) * Math.PI * 2;
+      spike.applyMatrix4(M(0.32 + Math.cos(a) * 0.16,
+        sp.profile.radius(0.32) * sp.profile.height + 0.24, Math.sin(a) * 0.16));
+      headParts.push({ geometry: spike.toNonIndexed(), color: C(0xfff3cf) });
+    }
+  }
+
+  /* --- Segment B: the mid body, hinged at the end of A --- */
+  const jointA = sp.profile.x(0.52);
+  const midGeo = bodySection(sp.profile, 0.52, 0.78, 4, rad, paint);
+  midGeo.translate(-jointA, 0, 0);
+  const midParts = [{ geometry: midGeo, color: finC }];
+  dorsalBlade(sp.dorsal, finC).forEach((g) => {
+    if (sp.dorsal.at <= -0.3) {
+      g.translate(-jointA, 0, 0);
+      midParts.push({ geometry: g, color: finC });
+    }
+  });
+  // Anal fin under the belly
+  midParts.push({
+    geometry: blade([[sp.profile.x(0.66) - jointA, 0], [sp.profile.x(0.72) - jointA, -0.26],
+      [sp.profile.x(0.78) - jointA, -0.05]], 0.04, finC),
+    color: finC
+  });
+  if (sp.adipose) {
+    midParts.push({
+      geometry: blade([[sp.adipose - jointA, 0], [sp.adipose - 0.05 - jointA, 0.13],
+        [sp.adipose - 0.12 - jointA, 0]], 0.035, finC),
+      color: finC
+    });
+  }
+
+  /* --- Segment C: peduncle plus the caudal fin --- */
+  const jointB = sp.profile.x(0.78);
+  const tailGeo = bodySection(sp.profile, 0.78, 1, 3, rad, paint);
+  tailGeo.translate(-jointB, 0, 0);
+  const tailParts = [{ geometry: tailGeo, color: finC }];
+  tailBlade(sp.tail, finC).forEach((g) => {
+    g.translate(sp.profile.x(1) - jointB, 0, 0);
+    tailParts.push({ geometry: g, color: finC });
+  });
+
+  return {
+    sp,
+    joints: [jointA, jointB],
+    geos: [mergeParts(headParts), mergeParts(midParts), mergeParts(tailParts)],
+    material: new THREE.MeshLambertMaterial({
+      vertexColors: true,
+      flatShading: true,
+      emissive: sp.rare ? 0x7a5300 : 0x000000,
+      emissiveIntensity: sp.rare ? 0.85 : 0
+    })
+  };
+}
+
+function buildJunk(j) {
+  const parts = [];
+  const dark = C(0x2f3542);
+  if (j.id === 'stovel') {
+    const shaft = new THREE.CylinderGeometry(0.2, 0.24, 0.8, 6);
+    shaft.applyMatrix4(M(0, 0.1, 0));
+    parts.push({ geometry: shaft.toNonIndexed(), color: C(0x24303a) });
+    const foot = new THREE.BoxGeometry(0.62, 0.24, 0.34);
+    foot.applyMatrix4(M(0.2, -0.4, 0));
+    parts.push({ geometry: foot.toNonIndexed(), color: C(0x1b242c) });
+  } else if (j.id === 'burk') {
+    const can = new THREE.CylinderGeometry(0.2, 0.2, 0.5, 8);
+    can.applyMatrix4(M(0, 0, 0, Math.PI / 2.4));
+    parts.push({ geometry: can.toNonIndexed(), color: C(0x8d7b5a) });
+    const lid = new THREE.CylinderGeometry(0.21, 0.21, 0.05, 8);
+    lid.applyMatrix4(M(0.2, 0.14, 0, Math.PI / 2.4));
+    parts.push({ geometry: lid.toNonIndexed(), color: C(0xb0a181) });
+  } else {
+    const tire = new THREE.TorusGeometry(0.42, 0.13, 5, 12);
+    parts.push({ geometry: tire.toNonIndexed(), color: dark });
+    const hub = new THREE.TorusGeometry(0.16, 0.04, 4, 8);
+    parts.push({ geometry: hub.toNonIndexed(), color: C(0x596273) });
+  }
+  return {
+    junk: j,
+    geometry: mergeParts(parts),
+    material: new THREE.MeshLambertMaterial({ vertexColors: true, flatShading: true })
+  };
+}
+
+/* --------------------------------------------------------------- instances */
+
+let ASSETS = null;
+
+export function fishAssets() {
+  if (!ASSETS) {
+    ASSETS = {
+      species: SPECIES.map(buildSpecies),
+      junk: JUNK.map(buildJunk)
+    };
+  }
+  return ASSETS;
+}
+
+/** Assemble one swimmer: a three-link chain that can undulate. */
+export function spawnFish(asset) {
+  const root = new THREE.Group();
+  const a = new THREE.Group();
+  const b = new THREE.Group();
+  const c = new THREE.Group();
+  a.add(new THREE.Mesh(asset.geos[0], asset.material));
+  b.add(new THREE.Mesh(asset.geos[1], asset.material));
+  c.add(new THREE.Mesh(asset.geos[2], asset.material));
+  b.position.x = asset.joints[0];
+  c.position.x = asset.joints[1] - asset.joints[0];
+  b.add(c);
+  a.add(b);
+  root.add(a);
+  root.scale.setScalar(asset.sp.size);
+  root.userData.links = [a, b, c];
+  return root;
+}
+
+export function spawnJunk(asset) {
+  const root = new THREE.Group();
+  root.add(new THREE.Mesh(asset.geometry, asset.material));
+  root.scale.setScalar(asset.junk.size);
+  root.userData.links = [];
+  return root;
+}
+
+/** Travelling wave down the body — the reason they look alive. */
+export function swim(root, t, speed, amp = 1) {
+  const { links } = root.userData;
+  if (!links || !links.length) return;
+  const w = t * (4 + speed);
+  links[0].rotation.y = Math.sin(w) * 0.06 * amp;
+  links[1].rotation.y = Math.sin(w - 0.9) * 0.2 * amp;
+  links[2].rotation.y = Math.sin(w - 1.8) * 0.42 * amp;
+}
+
+export function disposeAssets() {
+  if (!ASSETS) return;
+  ASSETS.species.forEach((a) => {
+    a.geos.forEach((g) => g.dispose());
+    a.material.dispose();
+  });
+  ASSETS.junk.forEach((a) => {
+    a.geometry.dispose();
+    a.material.dispose();
+  });
+  ASSETS = null;
+}

--- a/src/games/fishing/world.js
+++ b/src/games/fishing/world.js
@@ -1,0 +1,751 @@
+/**
+ * Pekkas Fiske — the lake.
+ *
+ * Built once, procedurally, with no downloaded assets:
+ *
+ *  - a gradient sky dome with a real midnight sun and its glow
+ *  - a water sheet displaced on the GPU, shaded differently above and
+ *    below the waterline: from underneath you get Snell's window (bright
+ *    straight up, mirrored at grazing angles) with caustics crawling
+ *    across it, from above a sun-glitter path
+ *  - a caustics texture generated from tiling wave interference, so it
+ *    loops seamlessly and costs one 256px canvas
+ *  - a rowboat with a tunna, an oar and a fisherman whose rod actually
+ *    bends when the reel turns
+ *  - light shafts that fade with vertex colour instead of alpha, so they
+ *    additively blend without sorting artefacts
+ *  - marine snow in a box that follows the camera, which is what sells
+ *    the sense of sinking
+ */
+
+import * as THREE from 'three';
+
+export const BOTTOM = 60;
+
+/* ------------------------------------------------------------- procedural */
+
+/** Seamless caustic web from summed tiling waves, ridged to thin filaments. */
+export function causticTexture(size = 256) {
+  const cv = document.createElement('canvas');
+  cv.width = size;
+  cv.height = size;
+  const ctx = cv.getContext('2d');
+  const img = ctx.createImageData(size, size);
+  const waves = [
+    [3, 1, 0.0], [1, 3, 1.1], [4, -2, 2.3],
+    [-2, 4, 3.7], [5, 3, 0.6], [3, -5, 4.2], [6, -1, 5.1]
+  ];
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      let v = 0;
+      for (let i = 0; i < waves.length; i++) {
+        const [m, n, ph] = waves[i];
+        v += Math.sin(2 * Math.PI * ((m * x) / size + (n * y) / size) + ph);
+      }
+      v /= waves.length;
+      const ridge = (1 - Math.abs(v)) ** 7;
+      const c = Math.min(255, ridge * 300);
+      const o = (y * size + x) * 4;
+      img.data[o] = c;
+      img.data[o + 1] = c;
+      img.data[o + 2] = c;
+      img.data[o + 3] = 255;
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+  const tex = new THREE.CanvasTexture(cv);
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.wrapT = THREE.RepeatWrapping;
+  return tex;
+}
+
+/** Soft round sprite for drifting particles. */
+export function sparkTexture(size = 64) {
+  const cv = document.createElement('canvas');
+  cv.width = size;
+  cv.height = size;
+  const ctx = cv.getContext('2d');
+  const g = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+  g.addColorStop(0, 'rgba(255,255,255,1)');
+  g.addColorStop(0.35, 'rgba(255,255,255,0.55)');
+  g.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, size, size);
+  return new THREE.CanvasTexture(cv);
+}
+
+/* ------------------------------------------------------------------- sky */
+
+export function buildSky() {
+  const uniforms = {
+    uZenith: { value: new THREE.Color(0x1d5b96) },
+    uHorizon: { value: new THREE.Color(0xffbe7d) },
+    uSunColor: { value: new THREE.Color(0xfff0c8) },
+    uSunDir: { value: new THREE.Vector3(0.16, 0.125, -0.978).normalize() },
+    uOpacity: { value: 1 }
+  };
+  const mat = new THREE.ShaderMaterial({
+    uniforms,
+    side: THREE.BackSide,
+    depthWrite: false,
+    transparent: true,
+    fog: false,
+    vertexShader: `
+      varying vec3 vDir;
+      void main() {
+        vDir = position;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: `
+      uniform vec3 uZenith, uHorizon, uSunColor, uSunDir;
+      uniform float uOpacity;
+      varying vec3 vDir;
+      void main() {
+        vec3 d = normalize(vDir);
+        // Almost all of the gradient happens in the first few degrees above
+        // the horizon — that is what makes a low sun read as a low sun.
+        float h = clamp(d.y, 0.0, 1.0);
+        vec3 c = mix(uHorizon, uZenith, pow(h, 0.42));
+        float s = max(dot(d, normalize(uSunDir)), 0.0);
+        c += uSunColor * smoothstep(0.9986, 0.9994, s) * 3.2;
+        c += uSunColor * pow(s, 26.0) * 0.75;
+        c += uSunColor * pow(s, 3.0) * 0.22;
+        gl_FragColor = vec4(c, uOpacity);
+        #include <tonemapping_fragment>
+        #include <colorspace_fragment>
+      }
+    `
+  });
+  const dome = new THREE.Mesh(new THREE.SphereGeometry(400, 24, 16), mat);
+  dome.renderOrder = -10;
+  return { dome, uniforms, material: mat };
+}
+
+/** Ridge line, two ranks of spruce and a few clouds — the composition. */
+export function buildShore() {
+  const g = new THREE.Group();
+  const rand = mulberry(7);
+
+  const ridge = (z, color, hScale, count, spread) => {
+    const parts = [];
+    for (let i = 0; i < count; i++) {
+      const h = (1.4 + rand() * 2.8) * hScale;
+      const w = (0.6 + rand() * 0.5) * hScale;
+      const tree = new THREE.ConeGeometry(w, h, 5);
+      tree.translate(-spread / 2 + (i / count) * spread + rand() * 3, h / 2, z + rand() * 6);
+      parts.push(tree.toNonIndexed());
+    }
+    const merged = mergeGeos(parts);
+    const m = new THREE.Mesh(merged, new THREE.MeshBasicMaterial({ color, fog: false }));
+    m.renderOrder = -8;
+    return m;
+  };
+
+  // Far range washed out by aerial perspective, near range darker
+  const hills = new THREE.Mesh(
+    hillGeometry(rand),
+    new THREE.MeshBasicMaterial({ color: 0x6d7f96, fog: false })
+  );
+  hills.position.set(0, 0, -260);
+  hills.renderOrder = -9;
+  g.add(hills);
+  g.add(ridge(-180, 0x4a5c6e, 3.4, 40, 420));
+  g.add(ridge(-120, 0x263341, 2.4, 46, 320));
+
+  const cloudMat = new THREE.MeshBasicMaterial({ color: 0xffdcb0, fog: false, transparent: true, opacity: 0.85 });
+  for (let i = 0; i < 7; i++) {
+    const cloud = new THREE.Group();
+    const n = 3 + Math.floor(rand() * 3);
+    for (let k = 0; k < n; k++) {
+      const s = 6 + rand() * 9;
+      const puff = new THREE.Mesh(new THREE.IcosahedronGeometry(s, 0), cloudMat);
+      puff.position.set(k * s * 1.1 - n * 3, rand() * s * 0.4, rand() * 6);
+      puff.scale.y = 0.45;
+      cloud.add(puff);
+    }
+    cloud.position.set(-220 + rand() * 440, 40 + rand() * 50, -220 - rand() * 90);
+    cloud.renderOrder = -9;
+    g.add(cloud);
+  }
+  return g;
+}
+
+function hillGeometry(rand) {
+  const pts = [];
+  const span = 900;
+  const n = 26;
+  const heights = [];
+  for (let i = 0; i <= n; i++) heights.push(14 + Math.sin(i * 0.7) * 10 + rand() * 16);
+  for (let i = 0; i < n; i++) {
+    const x0 = -span / 2 + (i / n) * span;
+    const x1 = -span / 2 + ((i + 1) / n) * span;
+    pts.push(x0, 0, 0, x1, 0, 0, x0, heights[i], 0);
+    pts.push(x1, 0, 0, x1, heights[i + 1], 0, x0, heights[i], 0);
+  }
+  const g = new THREE.BufferGeometry();
+  g.setAttribute('position', new THREE.BufferAttribute(new Float32Array(pts), 3));
+  g.computeVertexNormals();
+  return g;
+}
+
+function mulberry(seed) {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function mergeGeos(list) {
+  let total = 0;
+  list.forEach((g) => {
+    total += g.attributes.position.count;
+  });
+  const pos = new Float32Array(total * 3);
+  let o = 0;
+  list.forEach((g) => {
+    pos.set(g.attributes.position.array, o);
+    o += g.attributes.position.count * 3;
+    g.dispose();
+  });
+  const out = new THREE.BufferGeometry();
+  out.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  out.computeVertexNormals();
+  return out;
+}
+
+/* ----------------------------------------------------------------- water */
+
+export function buildWater(caustics) {
+  const uniforms = {
+    uTime: { value: 0 },
+    uCaustics: { value: caustics },
+    uSky: { value: new THREE.Color(0xffe0b4) },
+    uSkyRefl: { value: new THREE.Color(0x7ea8c6) },
+    uShallow: { value: new THREE.Color(0x2f9fa8) },
+    uDeepTint: { value: new THREE.Color(0x06202e) },
+    uSunDir: { value: new THREE.Vector3(0.16, 0.125, -0.978).normalize() },
+    uFogColor: { value: new THREE.Color(0x1d6b74) },
+    uFogDensity: { value: 0.02 },
+    uCausticStrength: { value: 1 }
+  };
+
+  const material = new THREE.ShaderMaterial({
+    uniforms,
+    side: THREE.DoubleSide,
+    transparent: true,
+    fog: false,
+    vertexShader: `
+      uniform float uTime;
+      varying vec3 vWorld;
+      varying vec3 vNrm;
+      varying float vDepth;
+
+      float h(vec2 p, float t) {
+        return sin(p.x * 0.32 + t * 1.10) * 0.30
+             + sin(p.y * 0.41 - t * 0.85) * 0.24
+             + sin((p.x + p.y) * 0.19 + t * 1.60) * 0.16
+             + sin(p.x * 1.70 + t * 2.60) * 0.045
+             + sin(p.y * 1.90 - t * 2.20) * 0.040;
+      }
+
+      void main() {
+        vec3 p = position;
+        vec4 w = modelMatrix * vec4(p, 1.0);
+        float t = uTime;
+        w.y += h(w.xz, t);
+        // Analytic normal from the same three waves
+        float dx = cos(w.x * 0.32 + t * 1.10) * 0.30 * 0.32
+                 + cos((w.x + w.z) * 0.19 + t * 1.60) * 0.16 * 0.19
+                 + cos(w.x * 1.70 + t * 2.60) * 0.045 * 1.70;
+        float dz = cos(w.z * 0.41 - t * 0.85) * 0.24 * 0.41
+                 + cos((w.x + w.z) * 0.19 + t * 1.60) * 0.16 * 0.19
+                 + cos(w.z * 1.90 - t * 2.20) * 0.040 * 1.90;
+        vNrm = normalize(vec3(-dx, 1.0, -dz));
+        vWorld = w.xyz;
+        vec4 mv = viewMatrix * w;
+        vDepth = -mv.z;
+        gl_Position = projectionMatrix * mv;
+      }
+    `,
+    fragmentShader: `
+      uniform sampler2D uCaustics;
+      uniform vec3 uSky, uSkyRefl, uShallow, uDeepTint, uSunDir, uFogColor;
+      uniform float uFogDensity, uTime, uCausticStrength;
+      varying vec3 vWorld;
+      varying vec3 vNrm;
+      varying float vDepth;
+
+      float web(vec2 p) {
+        float a = texture2D(uCaustics, p * 0.045 + vec2(uTime * 0.012, uTime * 0.008)).r;
+        float b = texture2D(uCaustics, p * 0.031 - vec2(uTime * 0.009, uTime * 0.014)).r;
+        return a * b * 2.4;
+      }
+
+      void main() {
+        vec3 N = normalize(vNrm);
+        vec3 V = normalize(cameraPosition - vWorld);
+        float facing = dot(N, V);
+        vec3 col;
+        float alpha;
+
+        if (facing < 0.0) {
+          // --- seen from underneath: Snell's window straight up, mirror at
+          // grazing angles, caustics crawling over the ceiling ---
+          float up = clamp(-facing, 0.0, 1.0);
+          float window = smoothstep(0.12, 0.62, up);
+          float caust = web(vWorld.xz) * uCausticStrength;
+          vec3 ceiling = mix(uDeepTint, uSky, window);
+          ceiling += vec3(0.55, 0.85, 0.8) * caust * (0.25 + window * 0.9);
+          col = ceiling;
+          alpha = 0.94;
+        } else {
+          // --- seen from above: sky tint, fresnel rim and a sun glitter path ---
+          float fres = pow(1.0 - clamp(facing, 0.0, 1.0), 5.0);
+          col = mix(uShallow, uSkyRefl, fres * 0.8);
+          vec3 H = normalize(normalize(uSunDir) + V);
+          float spec = pow(max(dot(N, H), 0.0), 160.0);
+          col += uSky * spec * 2.1;                       // the glitter path
+          col += vec3(0.45, 0.72, 0.7) * web(vWorld.xz) * 0.1 * uCausticStrength;
+          alpha = 0.82;
+        }
+
+        float f = 1.0 - exp(-uFogDensity * uFogDensity * vDepth * vDepth);
+        col = mix(col, uFogColor, f);
+        gl_FragColor = vec4(col, alpha);
+        #include <tonemapping_fragment>
+        #include <colorspace_fragment>
+      }
+    `
+  });
+
+  const geo = new THREE.PlaneGeometry(220, 150, 72, 44);
+  geo.rotateX(-Math.PI / 2);
+  const mesh = new THREE.Mesh(geo, material);
+  mesh.renderOrder = 2;
+  return { mesh, uniforms, material };
+}
+
+/* ------------------------------------------------------------------ boat */
+
+function woodMat(color) {
+  return new THREE.MeshLambertMaterial({ color, flatShading: true });
+}
+
+export function buildBoat() {
+  const g = new THREE.Group();
+
+  /* Hull: a side profile extruded across the beam, then pinched at bow
+     and stern so it stops being a slab and becomes a boat. */
+  const shape = new THREE.Shape();
+  shape.moveTo(-2.35, 0.62);
+  shape.lineTo(2.5, 0.86);
+  shape.lineTo(2.78, 0.18);
+  shape.quadraticCurveTo(1.4, -0.62, 0.1, -0.66);
+  shape.quadraticCurveTo(-1.5, -0.62, -2.35, -0.12);
+  shape.closePath();
+  const hullGeo = new THREE.ExtrudeGeometry(shape, { depth: 1.9, bevelEnabled: false, curveSegments: 4 });
+  hullGeo.translate(0, 0, -0.95);
+  const hp = hullGeo.attributes.position;
+  for (let i = 0; i < hp.count; i++) {
+    const x = hp.getX(i);
+    const k = Math.min(1, Math.max(0, (Math.abs(x) - 1.1) / 1.7));
+    hp.setZ(i, hp.getZ(i) * (1 - 0.72 * k * k));
+  }
+  hullGeo.computeVertexNormals();
+  const hull = new THREE.Mesh(hullGeo, woodMat(0x9c5f2c));
+  g.add(hull);
+
+  // Dark interior so the boat reads as open, not solid
+  const inner = new THREE.Mesh(
+    new THREE.BoxGeometry(4.2, 0.5, 1.35),
+    new THREE.MeshLambertMaterial({ color: 0x3d2413, flatShading: true })
+  );
+  inner.position.set(0.1, 0.5, 0);
+  g.add(inner);
+
+  // Gunwale
+  const rimMat = woodMat(0xc98a4b);
+  [1, -1].forEach((s) => {
+    const rail = new THREE.Mesh(new THREE.BoxGeometry(4.9, 0.16, 0.17), rimMat);
+    rail.position.set(0.1, 0.74, s * 0.72);
+    rail.rotation.y = s * 0.04;
+    g.add(rail);
+  });
+
+  // Thwarts
+  [-0.9, 0.9].forEach((x) => {
+    const seat = new THREE.Mesh(new THREE.BoxGeometry(0.5, 0.11, 1.5), rimMat);
+    seat.position.set(x, 0.72, 0);
+    g.add(seat);
+  });
+
+  /* The tunna — the target every tapped fish flies into */
+  const barrel = new THREE.Group();
+  const staves = new THREE.Mesh(new THREE.CylinderGeometry(0.46, 0.4, 0.95, 12, 1), woodMat(0x8a5a30));
+  barrel.add(staves);
+  [-0.3, 0.3].forEach((y) => {
+    const hoop = new THREE.Mesh(new THREE.TorusGeometry(0.455, 0.045, 4, 14), woodMat(0x4a4f5c));
+    hoop.rotation.x = Math.PI / 2;
+    hoop.position.y = y;
+    barrel.add(hoop);
+  });
+  barrel.position.set(1.75, 1.05, 0);
+  g.add(barrel);
+
+  /* Oar resting across the gunwale */
+  const oar = new THREE.Group();
+  const shaftMesh = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.06, 3.1, 6), woodMat(0xb07b40));
+  shaftMesh.rotation.z = Math.PI / 2;
+  oar.add(shaftMesh);
+  const bladeMesh = new THREE.Mesh(new THREE.BoxGeometry(0.7, 0.05, 0.3), woodMat(0xb07b40));
+  bladeMesh.position.x = -1.75;
+  oar.add(bladeMesh);
+  oar.position.set(-0.4, 0.86, -0.55);
+  oar.rotation.y = 0.22;
+  g.add(oar);
+
+  /* Fisherman */
+  const guy = new THREE.Group();
+  const skin = new THREE.MeshLambertMaterial({ color: 0xe6b184, flatShading: true });
+  const coat = new THREE.MeshLambertMaterial({ color: 0xf2c14e, flatShading: true });
+  const pants = new THREE.MeshLambertMaterial({ color: 0x2c4a72, flatShading: true });
+
+  [-0.22, 0.22].forEach((z) => {
+    const leg = new THREE.Mesh(new THREE.CylinderGeometry(0.14, 0.12, 0.62, 6), pants);
+    leg.position.set(0.12, 0.42, z);
+    guy.add(leg);
+    const boot = new THREE.Mesh(new THREE.BoxGeometry(0.34, 0.16, 0.24), new THREE.MeshLambertMaterial({ color: 0x22303c, flatShading: true }));
+    boot.position.set(0.2, 0.12, z);
+    guy.add(boot);
+  });
+
+  const torso = new THREE.Mesh(new THREE.CylinderGeometry(0.3, 0.4, 0.86, 7), coat);
+  torso.position.y = 1.14;
+  guy.add(torso);
+
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.25, 8, 6), skin);
+  head.position.y = 1.76;
+  guy.add(head);
+  const beard = new THREE.Mesh(new THREE.SphereGeometry(0.2, 7, 5), new THREE.MeshLambertMaterial({ color: 0xcbb59a, flatShading: true }));
+  beard.position.set(0.09, 1.66, 0);
+  beard.scale.set(0.9, 0.75, 0.85);
+  guy.add(beard);
+  const cap = new THREE.Mesh(new THREE.CylinderGeometry(0.26, 0.29, 0.2, 8), new THREE.MeshLambertMaterial({ color: 0xb23a48, flatShading: true }));
+  cap.position.y = 1.95;
+  guy.add(cap);
+  const brim = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.05, 0.42), new THREE.MeshLambertMaterial({ color: 0x8e2c38, flatShading: true }));
+  brim.position.set(0.26, 1.88, 0);
+  guy.add(brim);
+  const bobble = new THREE.Mesh(new THREE.SphereGeometry(0.09, 6, 5), new THREE.MeshLambertMaterial({ color: 0xf6f1e4, flatShading: true }));
+  bobble.position.y = 2.09;
+  guy.add(bobble);
+
+  // Arms + rod live in their own pivot so the cast can be animated
+  const arms = new THREE.Group();
+  arms.position.set(0.12, 1.42, 0);
+  [-0.34, 0.34].forEach((z) => {
+    const arm = new THREE.Mesh(new THREE.CylinderGeometry(0.1, 0.09, 0.72, 6), coat);
+    arm.position.set(0.2, -0.16, z);
+    arm.rotation.z = -0.95;
+    arms.add(arm);
+  });
+  const rod = new THREE.Group();
+  const rodMesh = new THREE.Mesh(new THREE.CylinderGeometry(0.022, 0.055, 3.0, 5), woodMat(0x2f2418));
+  rodMesh.position.x = 1.5;
+  rodMesh.rotation.z = Math.PI / 2;
+  rod.add(rodMesh);
+  const reel = new THREE.Mesh(new THREE.CylinderGeometry(0.15, 0.15, 0.12, 8), new THREE.MeshLambertMaterial({ color: 0x9aa4b8, flatShading: true }));
+  reel.position.set(0.34, -0.16, 0);
+  rod.add(reel);
+  rod.position.set(0.38, -0.28, 0.1);
+  rod.rotation.z = 0.5;
+  arms.add(rod);
+  guy.add(arms);
+
+  guy.position.set(-0.55, 0.5, 0);
+  guy.rotation.y = -0.12;
+  g.add(guy);
+
+  /* Foam ring where the hull meets the water */
+  const foam = new THREE.Mesh(
+    new THREE.RingGeometry(2.4, 3.0, 20),
+    new THREE.MeshBasicMaterial({
+      color: 0xdff5f2,
+      transparent: true,
+      opacity: 0.07,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+      side: THREE.DoubleSide
+    })
+  );
+  foam.rotation.x = -Math.PI / 2;
+  foam.scale.z = 0.62;
+  foam.position.y = 0.02;
+
+  g.userData = { guy, arms, rod, rodTip: new THREE.Vector3(2.9, 0, 0), barrel, foam, oar };
+  return g;
+}
+
+/* --------------------------------------------------------------- seabed */
+
+export function buildSeabed() {
+  const g = new THREE.Group();
+  const rand = mulberry(19);
+
+  const bed = new THREE.PlaneGeometry(180, 70, 34, 16);
+  bed.rotateX(-Math.PI / 2);
+  const bp = bed.attributes.position;
+  const colors = new Float32Array(bp.count * 3);
+  const c = new THREE.Color();
+  for (let i = 0; i < bp.count; i++) {
+    const x = bp.getX(i);
+    const z = bp.getZ(i);
+    const hgt =
+      Math.sin(x * 0.11) * 1.1 +
+      Math.cos(z * 0.17 + 1.2) * 0.8 +
+      Math.sin(x * 0.31 + z * 0.21) * 0.45;
+    bp.setY(i, hgt);
+    // Silt in the hollows, paler crests
+    c.set(0x1d2536).lerp(new THREE.Color(0x4b5468), Math.min(1, Math.max(0, hgt * 0.28 + 0.5)));
+    colors[i * 3] = c.r;
+    colors[i * 3 + 1] = c.g;
+    colors[i * 3 + 2] = c.b;
+  }
+  bed.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+  bed.computeVertexNormals();
+  g.add(new THREE.Mesh(bed, new THREE.MeshLambertMaterial({ vertexColors: true, flatShading: true })));
+
+  const stoneMat = new THREE.MeshLambertMaterial({ color: 0x39415a, flatShading: true });
+  for (let i = 0; i < 16; i++) {
+    const s = 0.5 + rand() * 1.5;
+    const stone = new THREE.Mesh(new THREE.DodecahedronGeometry(s, 0), stoneMat);
+    stone.position.set(-30 + rand() * 60, s * 0.35, -8 + rand() * 14);
+    stone.rotation.set(rand() * 3, rand() * 3, rand() * 3);
+    stone.scale.y = 0.6 + rand() * 0.4;
+    g.add(stone);
+  }
+
+  // A sunken rowboat, half buried — a landmark that says "you made it down"
+  const wreck = new THREE.Group();
+  const wshape = new THREE.Shape();
+  wshape.moveTo(-1.8, 0.4);
+  wshape.lineTo(1.9, 0.5);
+  wshape.lineTo(2.1, 0.1);
+  wshape.quadraticCurveTo(0, -0.5, -1.8, -0.05);
+  wshape.closePath();
+  const wg = new THREE.ExtrudeGeometry(wshape, { depth: 1.4, bevelEnabled: false, curveSegments: 3 });
+  wg.translate(0, 0, -0.7);
+  wreck.add(new THREE.Mesh(wg, new THREE.MeshLambertMaterial({ color: 0x2b3a3a, flatShading: true })));
+  wreck.position.set(-13, 0.5, -3);
+  wreck.rotation.set(0.2, 0.5, 0.35);
+  g.add(wreck);
+
+  const weeds = [];
+  const weedMat = new THREE.MeshLambertMaterial({ color: 0x1d5c46, flatShading: true, side: THREE.DoubleSide });
+  for (let i = 0; i < 26; i++) {
+    const h = 2.4 + rand() * 3.4;
+    const weed = new THREE.Mesh(new THREE.ConeGeometry(0.13, h, 4, 3), weedMat);
+    weed.position.set(-34 + rand() * 68, h / 2, -8 + rand() * 15);
+    weed.userData.phase = rand() * 6.28;
+    g.add(weed);
+    weeds.push(weed);
+  }
+
+  g.position.y = -BOTTOM - 1.4;
+  g.userData.weeds = weeds;
+  return g;
+}
+
+/* ---------------------------------------------------------- light shafts */
+
+export function buildShafts() {
+  const verts = [];
+  const cols = [];
+  const rand = mulberry(3);
+  const top = new THREE.Color(0xbfeee0);
+  const bottom = new THREE.Color(0x000000);
+  for (let i = 0; i < 12; i++) {
+    const x = -26 + i * 4.4 + rand() * 2.2;
+    const wTop = 0.9 + rand() * 1.1;
+    const wBot = wTop * 0.25;
+    const len = 16 + rand() * 12;
+    const lean = (rand() - 0.5) * 5;
+    const z = -6 - rand() * 8;
+    const quad = [
+      [x - wTop, 0, z], [x + wTop, 0, z],
+      [x + wBot + lean, -len, z], [x - wBot + lean, -len, z]
+    ];
+    const tri = [[0, 1, 2], [0, 2, 3]];
+    tri.forEach((t) => {
+      t.forEach((idx) => {
+        const p = quad[idx];
+        verts.push(p[0], p[1], p[2]);
+        const c = idx <= 1 ? top : bottom;
+        const fade = idx <= 1 ? 0.42 + rand() * 0.28 : 0;
+        cols.push(c.r * fade, c.g * fade, c.b * fade);
+      });
+    });
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(verts), 3));
+  geo.setAttribute('color', new THREE.BufferAttribute(new Float32Array(cols), 3));
+  const mat = new THREE.MeshBasicMaterial({
+    vertexColors: true,
+    transparent: true,
+    opacity: 0.34,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide,
+    fog: false
+  });
+  const mesh = new THREE.Mesh(geo, mat);
+  mesh.renderOrder = 3;
+  return mesh;
+}
+
+/* ------------------------------------------------------------- particles */
+
+/**
+ * Marine snow inside a box that follows the camera, wrapped modulo the box
+ * size — there is always something drifting past, at any depth.
+ */
+export function buildSnow(spark, count = 260, box = 30) {
+  const pos = new Float32Array(count * 3);
+  const rand = mulberry(11);
+  for (let i = 0; i < count; i++) {
+    pos[i * 3] = (rand() - 0.5) * box;
+    pos[i * 3 + 1] = (rand() - 0.5) * box;
+    pos[i * 3 + 2] = (rand() - 0.5) * box * 0.6;
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  const mat = new THREE.PointsMaterial({
+    map: spark,
+    color: 0xcfeee6,
+    size: 0.17,
+    sizeAttenuation: true,
+    transparent: true,
+    opacity: 0.55,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending
+  });
+  const points = new THREE.Points(geo, mat);
+  points.frustumCulled = false;
+  points.userData = { box, count };
+  return points;
+}
+
+/** Reusable burst: catch sparkles, splashes, bubbles off the lure. */
+export function buildBurst(spark, count = 160) {
+  const pos = new Float32Array(count * 3);
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  const mat = new THREE.PointsMaterial({
+    map: spark,
+    color: 0xffe9b8,
+    size: 0.2,
+    sizeAttenuation: true,
+    transparent: true,
+    opacity: 0.9,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending
+  });
+  const points = new THREE.Points(geo, mat);
+  points.frustumCulled = false;
+  const parts = [];
+  for (let i = 0; i < count; i++) parts.push({ life: 0, vx: 0, vy: 0, vz: 0 });
+  points.userData = { parts, next: 0, count };
+  // Park unused particles far away rather than at the origin
+  for (let i = 0; i < count; i++) pos[i * 3 + 1] = 9999;
+  return points;
+}
+
+export function emitBurst(points, x, y, z, n, speed, spread = 1) {
+  const { parts, count } = points.userData;
+  const arr = points.geometry.attributes.position.array;
+  for (let i = 0; i < n; i++) {
+    const idx = points.userData.next % count;
+    points.userData.next++;
+    const p = parts[idx];
+    p.life = 0.5 + Math.random() * 0.5;
+    const a = Math.random() * Math.PI * 2;
+    const e = Math.random() * Math.PI - Math.PI / 2;
+    p.vx = Math.cos(a) * Math.cos(e) * speed * (0.4 + Math.random());
+    p.vy = Math.sin(e) * speed * (0.4 + Math.random()) + speed * 0.35;
+    p.vz = Math.sin(a) * Math.cos(e) * speed * 0.4;
+    arr[idx * 3] = x + (Math.random() - 0.5) * spread;
+    arr[idx * 3 + 1] = y + (Math.random() - 0.5) * spread;
+    arr[idx * 3 + 2] = z + (Math.random() - 0.5) * spread * 0.5;
+  }
+  points.geometry.attributes.position.needsUpdate = true;
+}
+
+export function updateBurst(points, dt, gravity = -3) {
+  const { parts, count } = points.userData;
+  const arr = points.geometry.attributes.position.array;
+  let alive = false;
+  for (let i = 0; i < count; i++) {
+    const p = parts[i];
+    if (p.life <= 0) continue;
+    alive = true;
+    p.life -= dt;
+    p.vy += gravity * dt;
+    arr[i * 3] += p.vx * dt;
+    arr[i * 3 + 1] += p.vy * dt;
+    arr[i * 3 + 2] += p.vz * dt;
+    if (p.life <= 0) arr[i * 3 + 1] = 9999;
+  }
+  if (alive) points.geometry.attributes.position.needsUpdate = true;
+}
+
+/* -------------------------------------------------------------- the lure */
+
+export function buildLure() {
+  const g = new THREE.Group();
+  const body = new THREE.Mesh(
+    new THREE.CapsuleGeometry(0.15, 0.34, 3, 7),
+    new THREE.MeshLambertMaterial({ color: 0xd8394d, flatShading: true, emissive: 0x3a0a10 })
+  );
+  body.rotation.z = Math.PI / 2;
+  g.add(body);
+  const stripe = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.155, 0.155, 0.14, 7),
+    new THREE.MeshLambertMaterial({ color: 0xf4f0e2, flatShading: true })
+  );
+  stripe.rotation.z = Math.PI / 2;
+  g.add(stripe);
+  const hook = new THREE.Mesh(
+    new THREE.TorusGeometry(0.15, 0.035, 5, 9, Math.PI * 1.5),
+    new THREE.MeshLambertMaterial({ color: 0xdfe6ff })
+  );
+  hook.position.set(-0.28, -0.16, 0);
+  hook.rotation.z = Math.PI * 0.75;
+  g.add(hook);
+  const spinner = new THREE.Mesh(
+    new THREE.CircleGeometry(0.13, 5),
+    new THREE.MeshLambertMaterial({ color: 0xffd98a, side: THREE.DoubleSide, emissive: 0x4a3200 })
+  );
+  spinner.position.set(0.22, 0.02, 0);
+  g.add(spinner);
+  const glow = new THREE.PointLight(0xffd9a0, 1.1, 9, 2);
+  g.add(glow);
+  g.userData = { spinner, glow };
+  return g;
+}
+
+/** Fishing line as a sagging polyline that lags behind the lure. */
+export function buildLine(segments = 14) {
+  const pts = [];
+  for (let i = 0; i <= segments; i++) pts.push(new THREE.Vector3());
+  const geo = new THREE.BufferGeometry().setFromPoints(pts);
+  const mat = new THREE.LineBasicMaterial({ color: 0xeaf1fb, transparent: true, opacity: 0.55 });
+  const line = new THREE.Line(geo, mat);
+  line.userData = { segments, nodes: pts.map((p) => p.clone()) };
+  line.frustumCulled = false;
+  return line;
+}

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -1890,6 +1890,14 @@
    */
   const GAMES = [
     {
+      year: 2024,
+      title: 'Pekkas Fiske',
+      competition: 'Fisketävling',
+      tagline: 'Sänk draget djupt, kroka storgäddan och fånga allt på vägen upp.',
+      icon: '🎣',
+      module: 'src/games/fishing/index.js'
+    },
+    {
       year: 2025,
       title: 'Pekkas Pokal Flipper',
       competition: 'Flipper',

--- a/src/styles/games.css
+++ b/src/styles/games.css
@@ -857,19 +857,21 @@ body.game-open {
 }
 
 /* ==================================================================
-   Pekkas Fiske (2024) — HUD-tillägg ovanpå pb-basstilarna
+   Pekkas Fiske (2024) — HUD ovanpå pb-basstilarna
    ================================================================== */
 
 .fg-ui .pb-top {
   right: 104px; /* clear the mute button so the depth counter never hides */
 }
 
+/* Djupmätaren och kasträknaren */
+
 .fg-depth {
   font-family: var(--font-display);
   font-weight: 700;
-  font-size: 1.15rem;
-  color: #7fd8e8;
-  text-shadow: 0 0 16px rgba(127, 216, 232, 0.55);
+  font-size: 1.2rem;
+  color: #8fe3f2;
+  text-shadow: 0 0 18px rgba(127, 216, 232, 0.6);
   font-variant-numeric: tabular-nums;
 }
 
@@ -880,19 +882,88 @@ body.game-open {
   color: rgba(190, 199, 233, 0.65);
 }
 
+.pb-score.bump {
+  animation: fg-bump 0.28s ease-out;
+}
+
+@keyframes fg-bump {
+  0% { transform: scale(1); }
+  35% { transform: scale(1.13); }
+  100% { transform: scale(1); }
+}
+
+/* Multiplikatorn — samlas på vägen ner, spenderas på vägen upp */
+
+.fg-mult {
+  position: absolute;
+  left: 12px;
+  top: calc(max(10px, env(safe-area-inset-top)) + 62px);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.3rem;
+  letter-spacing: 0.02em;
+  color: #5eead4;
+  text-shadow: 0 0 18px rgba(94, 234, 212, 0.55);
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 0.2s ease, transform 0.2s ease, color 0.3s ease;
+  pointer-events: none;
+}
+
+.fg-mult.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.fg-mult.hot {
+  color: #f2c14e;
+  text-shadow: 0 0 22px rgba(242, 193, 78, 0.7);
+}
+
+/* Djupzonens namn — stort, kort, en gång per zon */
+
+.fg-zone {
+  position: absolute;
+  left: 50%;
+  top: 34%;
+  transform: translate(-50%, 0);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(1.2rem, 6vw, 2rem);
+  letter-spacing: 0.2em;
+  color: rgba(220, 244, 250, 0.95);
+  text-shadow: 0 0 30px rgba(10, 30, 45, 0.9);
+  opacity: 0;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.fg-zone.show {
+  animation: fg-zone 1.8s ease-out forwards;
+}
+
+@keyframes fg-zone {
+  0% { opacity: 0; letter-spacing: 0.5em; }
+  18% { opacity: 1; letter-spacing: 0.2em; }
+  70% { opacity: 1; }
+  100% { opacity: 0; letter-spacing: 0.16em; }
+}
+
+/* Fasetiketten */
+
 .fg-phase {
   position: absolute;
   left: 50%;
-  top: 14%;
+  top: 13%;
   transform: translate(-50%, -6px);
   padding: 0.35rem 0.95rem;
   border-radius: var(--r-pill);
-  background: rgba(6, 18, 30, 0.72);
-  border: 1px solid rgba(127, 216, 232, 0.35);
+  background: rgba(6, 18, 30, 0.7);
+  border: 1px solid rgba(127, 216, 232, 0.32);
   backdrop-filter: blur(8px);
-  font-size: 0.68rem;
+  font-size: 0.66rem;
   font-weight: 700;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.11em;
   text-transform: uppercase;
   white-space: nowrap;
   color: rgba(205, 236, 244, 0.92);
@@ -904,4 +975,128 @@ body.game-open {
 .fg-phase.show {
   opacity: 1;
   transform: translate(-50%, 0);
+}
+
+/* Flygande poängsiffror, förankrade i 3D-positionen */
+
+.fg-pops {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.fg-pop {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.95rem;
+  white-space: nowrap;
+  color: #fff4d6;
+  text-shadow: 0 2px 12px rgba(4, 12, 22, 0.95);
+  animation: fg-pop 1.1s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.fg-pop.mult {
+  color: #5eead4;
+  font-size: 1.15rem;
+}
+
+@keyframes fg-pop {
+  0% { opacity: 0; transform: translate(-50%, -30%) scale(0.7); }
+  16% { opacity: 1; transform: translate(-50%, -50%) scale(1.05); }
+  100% { opacity: 0; transform: translate(-50%, -160%) scale(1); }
+}
+
+/* Tryckvinjett: sluter sig ju djupare man kommer */
+
+.fg-vignette {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse at 50% 42%, rgba(0, 0, 0, 0) 42%, rgba(2, 8, 16, 0.55) 100%),
+    linear-gradient(to bottom, rgba(2, 10, 20, 0.28), rgba(0, 0, 0, 0) 26%);
+  mix-blend-mode: multiply;
+}
+
+/* Startpanelens tre steg och slutsummeringen */
+
+.fg-steps {
+  list-style: none;
+  margin: 0 0 14px;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+  text-align: left;
+}
+
+.fg-steps li {
+  position: relative;
+  padding-left: 20px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: rgba(224, 229, 250, 0.85);
+}
+
+.fg-steps li b {
+  color: #fff;
+  display: block;
+  font-size: 11.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.fg-steps li i {
+  position: absolute;
+  left: 0;
+  top: 5px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--c, #f2c14e);
+  box-shadow: 0 0 10px var(--c, #f2c14e);
+}
+
+.fg-catchlist {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  margin: -4px 0 14px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: rgba(127, 216, 232, 0.08);
+  border: 1px solid rgba(127, 216, 232, 0.2);
+  font-size: 12.5px;
+  color: rgba(205, 236, 244, 0.85);
+}
+
+.fg-catchlist b {
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 11px;
+  color: rgba(205, 236, 244, 0.6);
+}
+
+.fg-catchlist span {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  color: #8fe3f2;
+}
+
+.fg-catchlist[hidden] {
+  display: none;
+}
+
+/* Sjön ska synas bakom startpanelen — den är halva försäljningen */
+.fg-ui .pb-overlay {
+  background: linear-gradient(180deg, rgba(4, 12, 22, 0.5), rgba(3, 8, 16, 0.8));
+  backdrop-filter: blur(4px);
+}
+
+.fg-steps[hidden] {
+  display: none;
 }

--- a/src/styles/games.css
+++ b/src/styles/games.css
@@ -855,3 +855,53 @@ body.game-open {
 .pb-help-card .pb-btn {
   width: 100%;
 }
+
+/* ==================================================================
+   Pekkas Fiske (2024) — HUD-tillägg ovanpå pb-basstilarna
+   ================================================================== */
+
+.fg-ui .pb-top {
+  right: 104px; /* clear the mute button so the depth counter never hides */
+}
+
+.fg-depth {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.15rem;
+  color: #7fd8e8;
+  text-shadow: 0 0 16px rgba(127, 216, 232, 0.55);
+  font-variant-numeric: tabular-nums;
+}
+
+.fg-cast {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: rgba(190, 199, 233, 0.65);
+}
+
+.fg-phase {
+  position: absolute;
+  left: 50%;
+  top: 14%;
+  transform: translate(-50%, -6px);
+  padding: 0.35rem 0.95rem;
+  border-radius: var(--r-pill);
+  background: rgba(6, 18, 30, 0.72);
+  border: 1px solid rgba(127, 216, 232, 0.35);
+  backdrop-filter: blur(8px);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  color: rgba(205, 236, 244, 0.92);
+  opacity: 0;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  pointer-events: none;
+}
+
+.fg-phase.show {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}


### PR DESCRIPTION
Genomgripande omarbetning av 2024 års fiskespel efter research om hur underwater-rendering, procedurell modellering och game feel görs bäst i webbläsaren. Spelet är nu uppdelat i `species` / `world` / `audio` / `index`, i samma anda som flipperspelet.

## Rendering och atmosfär

- **ACES filmisk tonemappning** och explicit sRGB — hela paletten blir filmisk i stället för platt
- **Vattenytan förskjuts på GPU:n** (var en CPU-loop med `computeVertexNormals()` varje bildruta) och skuggas olika ovanifrån och underifrån: nerifrån **Snells fönster** — ljust rakt upp, spegel i sneda vinklar — med **kaustik** som kryper över taket; ovanifrån en solglitterstig
- **Kaustiktexturen** genereras ur kaklande vågintereferens, 256 px, sömlös i båda led
- **Himmelsdome** med gradient komprimerad mot horisonten, riktig midnattssol med glorja, bergsrygg, två granrader med luftperspektiv och moln — komposition i stället för en enfärgad bakgrund
- **Femstegs djupgradering** av färg, dimma och ljus i stället för en rak toning, med namngivna djupzoner
- **Marin snö** i en låda som följer kameran, så det alltid driver något förbi oavsett djup; **ljusschakt** som tonar ut med vertexfärg i stället för alpha, så additiv blandning slipper sorteringsproblem
- Tryckvinjett som sluter sig med djupet

## Modellering

- Varje art byggs från en **ryggradsprofil plus fenblad** och slås ihop till tre meshar per art: **53 draw calls och 11 000 trianglar med 56 fiskar i scenen**
- **Motskuggning och artmönster** — abborrens ränder, gäddans ljusa bönfläckar, laxens prickar, mörtens röda fenor — målas in i vertexfärgerna medan kroppen genereras, så det finns fortfarande inte en enda textur i vattnet
- Kroppen är en **tredelad ledkedja**, så fisken vågrör sig med en vandrande våg i stället för att vifta med en kon i bakänden
- Riktningsbyte sker med rotation i stället för negativ skala, som vände ljussättningen ut och in
- Ny båt med extruderat och avsmalnande skrov, **tunna**, åra och en fiskare vars spö laddas när veven går; sjunket vrak på botten

## Spel

- **Multiplikatorn byggs av att väja på vägen ner och spenderas på vägen upp.** Droppfasen hade tidigare ingen belöning alls — nu är den halva poängen.
- **Skräp** att undvika (stövel, burk, cykeldäck), **bottenkänningsbonus**, **djupzoner**, **perfekt kast**
- Kombon **multiplicerar poängen på riktigt** (styrde tidigare bara tonhöjden på ljudet)
- Träffytan tar hänsyn till **z**, så fisk långt in i bilden inte längre krokar en orättvist
- **Juice**: hit stop, kameraskakning, FOV-punch, partikelutbrott, flygande poängsiffror förankrade i 3D-positionen, vibration
- **Kastfasen klipper nu upp ovanför ytan** — den visades tidigare underifrån genom vattenytan

## Ljud

- Lågpassfilter på hela ljudbussen som sluter sig med djupet, plus en drönare som svävar upp i mörkret — världen blir bokstavligen dovare ju längre ner man kommer

## Verifiering

- ESLint: 0 fel
- Playwright, mobil (390×844, touch) och dator (1280×800): hela loopen genom alla tre faser × tre kast, poäng/rekord, omstart, städad teardown. **Noll konsolfel.**
- Visuell granskning av startvy, ytan, 6/22/25/55 m djup och kastfasen — sky-domen läckte igenom under ytan och två `[hidden]`-attribut slogs ut av `display`-regler; båda åtgärdade
- Rökprov av flipperspelet efter ändringarna i den delade `games.css` — oförändrat

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNPUzfNKbSE5eVpMupNbhb)_